### PR TITLE
Added availability service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.0.6",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=14.17.0"

--- a/src/interfaces/availability.interface.ts
+++ b/src/interfaces/availability.interface.ts
@@ -3,7 +3,7 @@ export interface ApiAvailabilityPeriod {
   end_time: string;
 }
 
-export interface ApiAvailabilityDates {
+export interface ApiAvailabilityDate {
   date: string;
   available: ApiAvailabilityPeriod[];
   unavailable: ApiAvailabilityPeriod[];
@@ -11,5 +11,5 @@ export interface ApiAvailabilityDates {
 
 export interface ApiAvailability {
   user: number;
-  dates: ApiAvailabilityDates[];
+  dates: ApiAvailabilityDate[];
 }

--- a/src/interfaces/query-params/availability-query-params.interface.ts
+++ b/src/interfaces/query-params/availability-query-params.interface.ts
@@ -1,5 +1,12 @@
 export interface AvailabilityQueryParams {
+  /** Start of date range for fetching availability (ISO date format `YYYY-MM-DD`) */
   start?: string;
+  /** End of date range for fetching availability (inclusive) (ISO date format `YYYY-MM-DD`)  */
   end?: string;
+  /**
+   * List of user IDs to get availability for
+   *
+   * If undefined, all users on the account will be selected
+   */
   users?: number[];
 }

--- a/src/models/availability.model.ts
+++ b/src/models/availability.model.ts
@@ -1,8 +1,8 @@
-import { ApiAvailability, ApiAvailabilityDates } from '../interfaces/index.js';
+import { ApiAvailability, ApiAvailabilityDate } from '../interfaces/index.js';
 
 export class Availability {
   public user: number;
-  public dates: ApiAvailabilityDates[];
+  public dates: ApiAvailabilityDate[];
 
   constructor(availability: ApiAvailability) {
     this.user = availability.user;

--- a/src/rotacloud.ts
+++ b/src/rotacloud.ts
@@ -1,6 +1,7 @@
 import {
   AccountsService,
   AttendanceService,
+  AvailabilityService,
   DaysOffService,
   GroupsService,
   LeaveEmbargoesService,
@@ -19,6 +20,7 @@ export class RotaCloud {
   public defaultAPIURI = 'https://api.rotacloud.com/v1';
   public accounts = new AccountsService();
   public attendance = new AttendanceService();
+  public availability = new AvailabilityService();
   public daysOff = new DaysOffService();
   public group = new GroupsService();
   public leaveEmbargoes = new LeaveEmbargoesService();

--- a/src/services/availability.service.ts
+++ b/src/services/availability.service.ts
@@ -1,0 +1,23 @@
+import { Service, Options, RequirementsOf } from './index.js';
+
+import { InternalQueryParams } from '../interfaces/query-params/internal-query-params.inteface.js';
+import { AvailabilityQueryParams } from '../interfaces/query-params/availability-query-params.interface.js';
+import { Availability } from '../models/availability.model.js';
+import { ApiAvailability } from '../interfaces/availability.interface.js';
+
+type RequiredProps = 'start' | 'end';
+type RequiredOptions<T> = RequirementsOf<Options<T>, 'params'>;
+
+export class AvailabilityService extends Service {
+  private apiPath = '/availability';
+
+  async *list(options: RequiredOptions<RequirementsOf<AvailabilityQueryParams, RequiredProps> & InternalQueryParams>) {
+    for await (const res of super.iterator<ApiAvailability>({ url: this.apiPath }, options)) {
+      yield new Availability(res);
+    }
+  }
+
+  listByPage(options: RequiredOptions<RequirementsOf<AvailabilityQueryParams, RequiredProps> & InternalQueryParams>) {
+    return super.iterator<ApiAvailability>({ url: this.apiPath }, options).byPage();
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,6 +1,7 @@
 export * from './service.js';
 export * from './accounts.service.js';
 export * from './attendance.service.js';
+export * from './availability.service.js';
 export * from './days-off.service.js';
 export * from './groups.service.js';
 export * from './leave-request.service.js';


### PR DESCRIPTION
Adds an availability service for the `/availability` endpoint supporting a list method.

Also included doc comments for the availability query parameters; version bump and renamed `ApiAvailabilityDates` to `ApiAvailabilityDate` (singular) to better reflect it's type
