### PR TITLE
fix: query params for getting users

### DIFF
--- a/src/interfaces/query-params/users-query-params.interface.ts
+++ b/src/interfaces/query-params/users-query-params.interface.ts
@@ -8,7 +8,6 @@ export interface UsersQueryParams {
   search?: string;
   order?: string;
   period?: string;
-  location?: number;
   start_time?: number;
   end_time?: number;
   start_date?: string;


### PR DESCRIPTION
Removed unsupported query parameter for getting users.
For context `locations` is supported on the API but `location` (singular) is not