### PR TITLE
story/RWA-10 - Fixed issue with publish shift API in SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=14.17.0"

--- a/src/services/shifts.service.ts
+++ b/src/services/shifts.service.ts
@@ -97,7 +97,7 @@ export class ShiftsService extends Service {
   publish(data: number[], options: { rawResponse: true } & Options): Promise<AxiosResponse<any, any>>;
   publish(data: number[], options: Options): Promise<number>;
   publish(data: number[], options?: Options) {
-    return super.fetch<ApiShift>({ url: '/shifts_published', data, method: 'POST' }).then(
+    return super.fetch<ApiShift>({ url: '/shifts_published', data: { shifts: data }, method: 'POST' }).then(
       (res) => Promise.resolve(options?.rawResponse ? res : res.status),
       (err) => Promise.reject(options?.rawResponse ? err : new ErrorResponse(err))
     );
@@ -107,7 +107,7 @@ export class ShiftsService extends Service {
   unpublish(data: number[], options: { rawResponse: true } & Options): Promise<AxiosResponse<any, any>>;
   unpublish(data: number[], options: Options): Promise<number>;
   unpublish(data: number[], options?: Options) {
-    return super.fetch<ApiShift>({ url: '/shifts_published', data, method: 'DELETE' }).then(
+    return super.fetch<ApiShift>({ url: '/shifts_published', data: { shifts: data }, method: 'DELETE' }).then(
       (res) => Promise.resolve(options?.rawResponse ? res : res.status),
       (err) => Promise.reject(options?.rawResponse ? err : new ErrorResponse(err))
     );


### PR DESCRIPTION
This fixes an issue with the current SDK where you can't publish or unpublish the shift.

Issue: missing `shifts` parameter in API call.

[RotaCloud API /shift_published](https://rotacloud.docs.apiary.io/#reference/0/shiftspublished/publish-shifts)