### PR TITLE
bug/RWA-857 Adds `location` property on UsersQueryParams

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=14.17.0"

--- a/src/interfaces/query-params/users-query-params.interface.ts
+++ b/src/interfaces/query-params/users-query-params.interface.ts
@@ -1,6 +1,14 @@
 export interface UsersQueryParams {
   ids?: number[];
   locations?: number[];
+  /**
+   * Works different from {UserQueryParams.locations},
+   * When filtering out employees for rota, this is more suggested,
+   * one scenario would be filtering out employees base on their starting and
+   * final working date, using {UserQueryParams.locations} will not work in tandem
+   * of {UserQueryParams.start_date} and {UserQueryParams.end_date}
+   */
+  location?: number;
   roles?: number[];
   only_managed?: boolean;
   include_self?: boolean;


### PR DESCRIPTION
This PR adds a `location` property on existing `UsersQueryParams`. This fixes an issue related to [bug/RWA-857](https://rotacloud.atlassian.net/browse/RWA-857). As investigation shows that we can't properly filter out users by their start_date and end_date by using `locations` array as a param. We'd need to use the single `location` id to filter users properly.