### PR TITLE
bug/RWA-938 - Shift: user property support null type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=14.17.0"

--- a/src/interfaces/shift.interface.ts
+++ b/src/interfaces/shift.interface.ts
@@ -8,7 +8,7 @@ export interface ApiShift {
   start_time: number;
   end_time: number;
   minutes_break: number;
-  user: number;
+  user: number | null;
   location: number;
   role: number | null;
   notes: string | null;

--- a/src/models/shift.model.ts
+++ b/src/models/shift.model.ts
@@ -10,7 +10,7 @@ export class Shift {
   public start_time: number;
   public end_time: number;
   public minutes_break: number;
-  public user: number;
+  public user: number | null;
   public location: number;
   public role: number | null;
   public notes: string | null;


### PR DESCRIPTION
Adding null type on shift user for supporting on amending shift with assigned user into an open shift. 
When editing a shift with assigned user, we should pass a null value on user in order for it to be processed by API as an open shift.
needed on :https://rotacloud.atlassian.net/browse/RWA-938