### PR TITLE
story/RWA 734 - Leave: add dry run to option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=14.17.0"

--- a/src/services/leave-request.service.ts
+++ b/src/services/leave-request.service.ts
@@ -19,8 +19,17 @@ export class LeaveRequestService extends Service {
   create(data: RequirementsOf<ApiLeaveRequest, RequiredProps>, options: Options): Promise<LeaveRequest>;
   create(data: RequirementsOf<ApiLeaveRequest, RequiredProps>, options?: Options) {
     return super
-      .fetch<ApiLeaveRequest>({ url: this.apiPath, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : new LeaveRequest(res.data)));
+      .fetch<ApiLeaveRequest>({
+        url: options?.dryRun ? `${this.apiPath}?dry_run=true` : this.apiPath,
+        data,
+        method: 'POST',
+      })
+      .then((res) => {
+        if (options?.dryRun) {
+          return Promise.resolve(res);
+        }
+        return Promise.resolve(options?.rawResponse ? res : new LeaveRequest(res.data));
+      });
   }
 
   get(id: number): Promise<LeaveRequest>;

--- a/src/services/leave.service.ts
+++ b/src/services/leave.service.ts
@@ -16,13 +16,18 @@ export class LeaveService extends Service {
   create(data: RequirementsOf<ApiLeave, RequiredProps>): Promise<Leave[]>;
   create(
     data: RequirementsOf<ApiLeave, RequiredProps>,
-    options: { rawResponse: true } & Options
+    options: { rawResponse: true; dryRun: false } & Options
   ): Promise<AxiosResponse<ApiLeave[], any>>;
   create(data: RequirementsOf<ApiLeave, RequiredProps>, options: Options): Promise<Leave[]>;
   create(data: RequirementsOf<ApiLeave, RequiredProps>, options?: Options) {
     return super
-      .fetch<ApiLeave[]>({ url: this.apiPath, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : [...res.data.map((leave) => new Leave(leave))]));
+      .fetch<ApiLeave[]>({ url: options?.dryRun ? `${this.apiPath}?dry_run=true` : this.apiPath, data, method: 'POST' })
+      .then((res) => {
+        if (options?.dryRun) {
+          return Promise.resolve(res);
+        }
+        return Promise.resolve(options?.rawResponse ? res : [...res.data.map((leave) => new Leave(leave))]);
+      });
   }
 
   get(id: number): Promise<Leave>;

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -47,6 +47,7 @@ export interface Options {
   expand?: string[];
   fields?: string[];
   limit?: number;
+  dryRun?: boolean;
 }
 
 interface PagingObject {


### PR DESCRIPTION
ticket https://rotacloud.atlassian.net/jira/software/projects/RWA/boards/72?selectedIssue=RWA-734

Added `?dry_run=true` in options . This is for calls where we want to assess errors or clashing leaves before committing to the action.