### PR TITLE
Update SDK ApiLeaveDate and Leave to support null hours

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "1.0.42",
+  "version": "1.0.44",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "1.0.42",
+      "version": "1.0.44",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.0.42",
+  "version": "1.0.44",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=14.17.0"

--- a/src/interfaces/leave-date.interface.ts
+++ b/src/interfaces/leave-date.interface.ts
@@ -2,7 +2,7 @@ export interface ApiLeaveDate {
   date: string;
   year: string;
   days: number;
-  hours: number;
+  hours: number | null;
   day_off: boolean;
   id?: number;
 }

--- a/src/interfaces/leave.interface.ts
+++ b/src/interfaces/leave.interface.ts
@@ -16,7 +16,7 @@ export interface ApiLeave {
   start_am_pm: string;
   end_date: string;
   end_am_pm: string;
-  hours: { [key: string]: number };
+  hours: { [key: string]: number | null };
   hours_method: string;
   hours_set: boolean;
   dates: ApiLeaveDate[];

--- a/src/models/leave.model.ts
+++ b/src/models/leave.model.ts
@@ -18,7 +18,7 @@ export class Leave {
   public admin: number;
   public start_am_pm: string;
   public end_am_pm: string;
-  public hours: { [key: string]: number };
+  public hours: { [key: string]: number | null };
   public hours_method: string;
   public hours_set: boolean;
   public requested_at: number;


### PR DESCRIPTION
https://rotacloud.atlassian.net/browse/RWA-1076

I want to enable the `hours `property of `ApiLeaveDate  `and `Leave `to support null as this would be used in creating separation on total hours if the hours method is yearly or daily

example request A: if yearly, hours should be set to null 
![image](https://github.com/rotacloud/rotacloud-node/assets/107027759/a4e5161c-3d38-4db9-9f9a-8f1b1221aa3b)

example request B: if daily, hours should be set to null 
![image](https://github.com/rotacloud/rotacloud-node/assets/107027759/fb633cb2-e6be-4605-b4bf-e6724ff5a50d)

