### PR TITLE
fix: missing properties on leave type model

### DIFF
--- a/src/models/leave-type.model.ts
+++ b/src/models/leave-type.model.ts
@@ -11,5 +11,9 @@ export class LeaveType {
   constructor(leaveType: ApiLeaveType) {
     this.id = leaveType.id;
     this.name = leaveType.name;
+    this.short_name = leaveType.short_name;
+    this.colour = leaveType.colour;
+    this.can_request = leaveType.can_request;
+    this.time_attendance_only = leaveType.time_attendance_only;
   }
 }


### PR DESCRIPTION
Fixed model not setting missing properties for `LeaveType`