### PR TITLE
SDK: dry_run support for Leave Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "1.0.45",
+      "version": "1.0.46",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=14.17.0"

--- a/src/services/leave.service.ts
+++ b/src/services/leave.service.ts
@@ -68,11 +68,14 @@ export class LeaveService extends Service {
   update(id: number, data: Partial<ApiLeave>, options: Options): Promise<Leave>;
   update(id: number, data: Partial<ApiLeave>, options?: Options) {
     return super
-      .fetch<ApiLeave>({
-        url: `${this.apiPath}/${id}`,
-        data,
-        method: 'POST',
-      })
+      .fetch<ApiLeave>(
+        {
+          url: `${this.apiPath}/${id}`,
+          data,
+          method: 'POST',
+        },
+        options
+      )
       .then((res) => Promise.resolve(options?.rawResponse ? res : new Leave(res.data)));
   }
 


### PR DESCRIPTION
ticket https://rotacloud.atlassian.net/browse/RWA-1126

dry_run is already added as option previously on  #72  but the options wasn't passed on the leave service-update
