### PR TITLE
story/RWA-813 - Made `year` optional for toil accrual query param

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=14.17.0"

--- a/src/interfaces/query-params/toil-accruals-query-params.interface.ts
+++ b/src/interfaces/query-params/toil-accruals-query-params.interface.ts
@@ -1,4 +1,4 @@
 export interface ToilAccrualsQueryParams {
-  year: number;
+  year?: number;
   users?: number[];
 }


### PR DESCRIPTION
Recent changes on the API now does not require you to pass in a year before you could get the accrual records of an employee.