### PR TITLE
bug/RWA-1189 - feat: simplify pagination by removing reliance on `link` header

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Build
         run: npm run build --if-present
+
+      - name: Publishable
+        run: npm publish --dry-run

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,33 @@
+name: Check
+on:
+  workflow_call:
+    inputs:
+      NODE_VERSION:
+        type: string
+        description: 'The version of Node to run the checks with'
+        default: 16.10
+  pull_request:
+    branches: [develop]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ inputs.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.NODE_VERSION }}
+          cache: 'npm'
+          registry-url: https://registry.npmjs.org/
+
+      - name: npm install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build --if-present

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,40 +2,39 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Publish
-
 on:
   push:
     branches: [main]
 
 jobs:
+  check:
+    uses: ./.github/workflows/check.yml
+
   publish:
     runs-on: ubuntu-latest
-
+    needs: [check]
     strategy:
       matrix:
-        node-version: [14.17]
+        node-version: [16.10]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
           registry-url: https://registry.npmjs.org/
+
       - name: Add version number to package
         run: |
           version=$(node -pe "require('./package.json').version")
           echo "Version is $version"
           echo "export const Version = { version: '$version' };" > ./src/version.ts
-      - name: Run CI
-        run: npm ci
-      - name: Lint
-        run: npm run lint
-      - name: Build
-        run: npm run build --if-present
+
       - name: Publish
         run: npm publish
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "1.0.54",
+      "version": "1.0.55",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.11.7",
@@ -27,7 +27,7 @@
         "typescript": "^5.1.6"
       },
       "engines": {
-        "node": ">=14.17.0"
+        "node": ">=16.10.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.54",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
-    "node": ">=14.17.0"
+    "node": ">=16.10.0"
   },
   "main": "./dist/cjs/rotacloud.js",
   "module": "./dist/mjs/rotacloud.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=16.10.0"

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -27,6 +27,15 @@ export type RetryOptions =
       maxRetries: number;
     };
 
+export interface Options {
+  rawResponse?: boolean;
+  expand?: string[];
+  fields?: string[];
+  limit?: number;
+  offset?: number;
+  dryRun?: boolean;
+}
+
 const DEFAULT_RETRIES = 3;
 const DEFAULT_RETRY_DELAY = 2000;
 
@@ -42,24 +51,36 @@ const DEFAULT_RETRY_STRATEGY_OPTIONS: Record<RetryStrategy, RetryOptions> = {
   },
 };
 
-export interface Options {
-  rawResponse?: boolean;
-  expand?: string[];
-  fields?: string[];
-  limit?: number;
-  offset?: number;
-  dryRun?: boolean;
-}
-
-interface PagingObject {
-  first: string;
-  prev: string;
-  next: string;
-  last: string;
-}
+const PERSISTENT_PARAMS = new Set(['expand', 'fields', 'limit', 'offset', 'dry_run', 'exclude_link_header']);
 
 type ParameterPrimitive = string | boolean | number | null;
 type ParameterValue = ParameterPrimitive | ParameterPrimitive[] | undefined;
+
+function* enumerate<T>(iter: Iterable<T>): Generator<[index: number, item: T]> {
+  let idx = 0;
+  for (const item of iter) {
+    yield [idx, item];
+    idx += 1;
+  }
+}
+
+/** Iterates through all {@see AsyncIterator}s in turn such that all iterators
+ * that aren't marked as "done" must return a value before they can return another.
+ */
+async function* asyncIterInTurn<T>(iters: Iterable<AsyncIterator<T>>): AsyncGenerator<T> {
+  const remaining = [...iters];
+  while (remaining.length > 0) {
+    for (const [idx, iter] of enumerate(remaining)) {
+      const { done, value } = await iter.next();
+      if (done) {
+        remaining.splice(idx, 1);
+        break;
+      }
+
+      yield value;
+    }
+  }
+}
 
 export abstract class Service<ApiResponse = any> {
   protected client: AxiosInstance = this.initialiseAxios();
@@ -90,13 +111,22 @@ export abstract class Service<ApiResponse = any> {
     return new SDKError(sdkErrorParams);
   }
 
-  public isLeaveRequest(endpoint?: string): boolean {
+  private isLeaveRequest(endpoint?: string): boolean {
     return endpoint === '/leave_requests';
   }
 
-  private buildQueryStr(queryParams: Record<string, ParameterValue> | undefined) {
-    if (!queryParams) return '';
-    const reducedParams = Object.entries(queryParams).reduce((params, [key, val]) => {
+  private buildQueryParams(options?: Options, extraParams?: Record<string, ParameterValue>) {
+    const queryParams: Record<string, ParameterValue> = {
+      expand: options?.expand,
+      fields: options?.fields,
+      limit: options?.limit,
+      offset: options?.offset,
+      dry_run: options?.dryRun,
+      ...extraParams,
+      // NOTE: Should not overridable so must come after spread of params
+      exclude_link_header: true,
+    };
+    const reducedParams = Object.entries(queryParams ?? {}).reduce((params, [key, val]) => {
       if (val !== undefined && val !== '') {
         if (Array.isArray(val)) params.push(...val.map((item) => [`${key}[]`, String(item)]));
         else params.push([key, String(val)]);
@@ -104,20 +134,38 @@ export abstract class Service<ApiResponse = any> {
       return params;
     }, [] as string[][]);
 
-    return new URLSearchParams(reducedParams).toString();
+    return new URLSearchParams(reducedParams);
   }
 
-  private parsePageLinkHeader(linkHeader: string): Partial<PagingObject> {
-    const pageData = {};
-    for (const link of linkHeader.split(',')) {
-      const { rel, url } = link.match(/<(?<url>.*)>; rel="(?<rel>\w*)"/)?.groups ?? {};
-      pageData[rel] = url;
+  /** Batches up query parameters to prevent URLs from becoming too large.
+   *
+   * Special query params such as 'limit' and 'offset' will be preserved in every batch
+   */
+  private *batchParams(queryParams: URLSearchParams) {
+    const maxParams = 300;
+    if (queryParams.size <= maxParams) {
+      yield queryParams;
+      return;
     }
 
-    return pageData;
+    const baseParams = new URLSearchParams();
+    for (const paramName of PERSISTENT_PARAMS) {
+      const paramVal = queryParams.get(paramName);
+      if (paramVal) baseParams.append(paramName, paramVal);
+    }
+
+    let paramChunk = new URLSearchParams(baseParams);
+    for (const [key, value] of queryParams) {
+      if (!PERSISTENT_PARAMS.has(key)) paramChunk.append(key, value);
+      if (paramChunk.size === maxParams) {
+        yield paramChunk;
+        paramChunk = new URLSearchParams(baseParams);
+      }
+    }
+    if (paramChunk.size > baseParams.size) yield paramChunk;
   }
 
-  public fetch<T = ApiResponse>(httpOptions: AxiosRequestConfig, options?: Options): Promise<AxiosResponse<T>> {
+  fetch<T = ApiResponse>(reqConfig: AxiosRequestConfig, options?: Options): Promise<AxiosResponse<T>> {
     const headers: Record<string, string> = {
       Authorization: `Bearer ${RotaCloud.config.apiKey}`,
       'SDK-Version': Version.version,
@@ -136,22 +184,14 @@ export abstract class Service<ApiResponse = any> {
       headers.Account = String(RotaCloud.config.accountId);
     } else {
       // need to convert user field in payload to a header for creating leave_requests when using an API key
-      this.isLeaveRequest(httpOptions.url) ? (headers.User = `${httpOptions.data.user}`) : undefined;
+      this.isLeaveRequest(reqConfig.url) ? (headers.User = `${reqConfig.data.user}`) : undefined;
     }
 
-    const reqObject: AxiosRequestConfig<T> = {
-      ...httpOptions,
+    const finalReqConfig: AxiosRequestConfig<T> = {
+      ...reqConfig,
       baseURL: RotaCloud.config.baseUri,
       headers,
-      params: {
-        expand: options?.expand,
-        fields: options?.fields,
-        limit: options?.limit,
-        offset: options?.offset,
-        dry_run: options?.dryRun,
-        ...httpOptions?.params,
-      },
-      paramsSerializer: this.buildQueryStr,
+      params: this.buildQueryParams(options, reqConfig.params),
     };
 
     if (RotaCloud.config.retry) {
@@ -171,50 +211,57 @@ export abstract class Service<ApiResponse = any> {
       });
     }
 
-    return this.client.request<T>(reqObject);
+    return this.client.request<T>(finalReqConfig);
   }
 
-  private async *listFetch<T = ApiResponse>(
-    reqObject: AxiosRequestConfig<T[]>,
+  /** Splits the request into batches and returns the result for each batch in page order */
+  private async *batchFetch<T = ApiResponse>(
+    reqConfig: AxiosRequestConfig<T[]>,
     options?: Options
-  ): AsyncGenerator<AxiosResponse<T[], any>> {
-    let pageRequestObject = reqObject;
-    let currentPageUrl = pageRequestObject.url;
+  ): AsyncGenerator<AxiosResponse<T[]>> {
+    const reqParams = this.buildQueryParams(options, reqConfig.params);
 
-    let pageRemaining = true;
-    while (pageRemaining) {
-      const res = await this.fetch<T[]>(pageRequestObject, options);
-      const pageLinkMap = this.parsePageLinkHeader(res.headers.link ?? '');
-      pageRemaining = Boolean(pageLinkMap.next);
-      // NOTE: query params including paging options are included in the "next" link
-      pageRequestObject = { url: pageLinkMap.next };
+    const batchedRequests: AsyncGenerator<AxiosResponse<T[]>>[] = [];
+    for (const params of this.batchParams(reqParams)) {
+      const batchedReqConfig = {
+        ...reqConfig,
+        params,
+      };
+      batchedRequests.push(this.fetchPages(batchedReqConfig, options));
+    }
+
+    for await (const res of asyncIterInTurn(batchedRequests)) {
       yield res;
-
-      // Failsafe incase the page does not change
-      if (currentPageUrl === pageRequestObject.url) {
-        throw new Error('Next page link did not change');
-      }
-      currentPageUrl = pageRequestObject.url;
     }
   }
 
-  private async *listResponses<T = ApiResponse>(reqObject: AxiosRequestConfig<T[]>, options?: Options) {
-    for await (const res of this.listFetch<T>(reqObject, options)) {
+  /** Iterates through every page for a potentially paginated request */
+  private async *fetchPages<T>(
+    reqConfig: AxiosRequestConfig<T[]>,
+    options: Options | undefined
+  ): AsyncGenerator<AxiosResponse<T[]>> {
+    const res = await this.fetch<T[]>(reqConfig, options);
+    yield res;
+
+    const limit = Number(res.headers['x-limit'] ?? 1);
+    const entityCount = Number(res.headers['x-total-count'] ?? 0);
+    const requestOffset = Number(res.headers['x-offset'] ?? 0);
+
+    for (let offset = requestOffset + limit; offset < entityCount; offset += limit) {
+      yield this.fetch<T[]>(reqConfig, { ...options, offset });
+    }
+  }
+
+  private async *listResponses<T = ApiResponse>(reqConfig: AxiosRequestConfig<T[]>, options?: Options) {
+    for await (const res of this.batchFetch<T>(reqConfig, options)) {
       yield* res.data;
     }
   }
 
-  public iterator<T = ApiResponse>(reqObject: AxiosRequestConfig<T[]>, options?: Options) {
-    const iterator = this.listResponses<T>(reqObject, options);
+  iterator<T = ApiResponse>(reqConfig: AxiosRequestConfig<T[]>, options?: Options) {
     return {
-      [Symbol.asyncIterator]() {
-        return {
-          next() {
-            return iterator.next();
-          },
-        };
-      },
-      byPage: () => this.listFetch<T>(reqObject, options),
+      [Symbol.asyncIterator]: () => this.listResponses<T>(reqConfig, options),
+      byPage: () => this.batchFetch<T>(reqConfig, options),
     };
   }
 }

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -240,12 +240,13 @@ export abstract class Service<ApiResponse = any> {
     reqConfig: AxiosRequestConfig<T[]>,
     options: Options | undefined
   ): AsyncGenerator<AxiosResponse<T[]>> {
+    const fallbackLimit = 20;
     const res = await this.fetch<T[]>(reqConfig, options);
     yield res;
 
-    const limit = Number(res.headers['x-limit'] ?? 1);
-    const entityCount = Number(res.headers['x-total-count'] ?? 0);
-    const requestOffset = Number(res.headers['x-offset'] ?? 0);
+    const limit = Number(res.headers['x-limit']) || fallbackLimit;
+    const entityCount = Number(res.headers['x-total-count']) || 0;
+    const requestOffset = Number(res.headers['x-offset']) || entityCount;
 
     for (let offset = requestOffset + limit; offset < entityCount; offset += limit) {
       yield this.fetch<T[]>(reqConfig, { ...options, offset });

--- a/src/services/shifts.service.ts
+++ b/src/services/shifts.service.ts
@@ -75,6 +75,7 @@ export class ShiftsService extends Service {
         .fetch<ApiShift>({
           url: `${this.apiPath}/${shifts.id}`,
           data: shifts,
+          method: 'POST',
         })
         .then((res) => (options?.rawResponse ? res : new Shift(res.data)));
     }


### PR DESCRIPTION
Adds support for pagination solely via the `limit`, `offset` and `total-count` headers and sets the new API query param `exclude_link_header=true` for all requests to prevent too large header payloads 