### PR TITLE
story/RWA-867 - feat: stricter options and support for `fields` types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.11.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=16.10.0"

--- a/src/interfaces/query-params/index.ts
+++ b/src/interfaces/query-params/index.ts
@@ -9,7 +9,6 @@ export * from './days-off-patterns-query-params.interface.js';
 export * from './days-off-query-params.interface.js';
 export * from './documents-query-params.interface.js';
 export * from './groups-query-params.interface.js';
-export * from './internal-query-params.interface.js';
 export * from './leave-embargoes-query-params.interface.js';
 export * from './leave-query-params.interface.js';
 export * from './leave-requests-query-params.interface.js';

--- a/src/interfaces/query-params/internal-query-params.interface.ts
+++ b/src/interfaces/query-params/internal-query-params.interface.ts
@@ -1,5 +1,0 @@
-export interface InternalQueryParams {
-  expand?: string[];
-  fields?: string[];
-  limit?: number;
-}

--- a/src/services/accounts.service.ts
+++ b/src/services/accounts.service.ts
@@ -31,7 +31,7 @@ export class AccountsService extends Service<Account> {
   }
 
   listAll(): Promise<Account[]>;
-  listAll<F extends keyof Account>(options: { fields: F[] } & OptionsExtended<Account[]>): Promise<Pick<Account, F>[]>;
+  listAll<F extends keyof Account>(options: { fields: F[] } & OptionsExtended<Account>): Promise<Pick<Account, F>[]>;
   listAll(options?: OptionsExtended<Account>): Promise<Account[]>;
   async listAll(options?: OptionsExtended<Account>) {
     const accounts = [] as Account[];
@@ -43,7 +43,7 @@ export class AccountsService extends Service<Account> {
 
   listByPage(): AsyncGenerator<AxiosResponse<Account[]>>;
   listByPage<F extends keyof Account>(
-    options: { fields: F[] } & OptionsExtended<Account[]>,
+    options: { fields: F[] } & OptionsExtended<Account>,
   ): AsyncGenerator<AxiosResponse<Pick<Account, F>[]>>;
   listByPage(options: OptionsExtended<Account>): AsyncGenerator<AxiosResponse<Account[]>>;
   listByPage(options?: Options) {

--- a/src/services/accounts.service.ts
+++ b/src/services/accounts.service.ts
@@ -46,7 +46,7 @@ export class AccountsService extends Service<Account> {
     options: { fields: F[] } & OptionsExtended<Account>,
   ): AsyncGenerator<AxiosResponse<Pick<Account, F>[]>>;
   listByPage(options: OptionsExtended<Account>): AsyncGenerator<AxiosResponse<Account[]>>;
-  listByPage(options?: Options) {
+  listByPage(options?: OptionsExtended<Account>) {
     return super.iterator({ url: this.apiPath }, options).byPage();
   }
 }

--- a/src/services/accounts.service.ts
+++ b/src/services/accounts.service.ts
@@ -1,28 +1,39 @@
 import { AxiosResponse } from 'axios';
-import { Service, Options } from './index.js';
+import { Service, Options, OptionsExtended } from './index.js';
 
 import { Account } from '../interfaces/index.js';
 
-export class AccountsService extends Service {
+export class AccountsService extends Service<Account> {
   private apiPath = '/accounts';
 
   get(id: number): Promise<Account>;
-  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<Account, any>>;
-  get(id: number, options: Options): Promise<Account>;
-  get(id: number, options?: Options) {
+  get<F extends keyof Account>(
+    id: number,
+    options: { fields: F[]; rawResponse: true } & OptionsExtended<Account>,
+  ): Promise<AxiosResponse<Pick<Account, F>>>;
+  get<F extends keyof Account>(
+    id: number,
+    options: { fields: F[] } & OptionsExtended<Account>,
+  ): Promise<Pick<Account, F>>;
+  get(id: number, options: { rawResponse: true } & OptionsExtended<Account>): Promise<AxiosResponse<Account>>;
+  get(id: number, options?: OptionsExtended<Account>): Promise<Account>;
+  get(id: number, options?: OptionsExtended<Account>) {
     return super
       .fetch<Account>({ url: `${this.apiPath}/${id}` }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  async *list(options?: Options) {
-    for await (const res of super.iterator<Account>({ url: this.apiPath }, options)) {
-      yield res;
-    }
+  list(): AsyncGenerator<Account>;
+  list<F extends keyof Account>(options: { fields: F[] } & OptionsExtended<Account>): AsyncGenerator<Pick<Account, F>>;
+  list(options?: OptionsExtended<Account>): AsyncGenerator<Account>;
+  async *list(options?: OptionsExtended<Account>) {
+    yield* super.iterator({ url: this.apiPath }, options);
   }
 
-  listAll(options?: Options): Promise<Account[]>;
-  async listAll(options?: Options) {
+  listAll(): Promise<Account[]>;
+  listAll<F extends keyof Account>(options: { fields: F[] } & OptionsExtended<Account[]>): Promise<Pick<Account, F>[]>;
+  listAll(options?: OptionsExtended<Account>): Promise<Account[]>;
+  async listAll(options?: OptionsExtended<Account>) {
     const accounts = [] as Account[];
     for await (const account of this.list(options)) {
       accounts.push(account);
@@ -30,7 +41,12 @@ export class AccountsService extends Service {
     return accounts;
   }
 
+  listByPage(): AsyncGenerator<AxiosResponse<Account[]>>;
+  listByPage<F extends keyof Account>(
+    options: { fields: F[] } & OptionsExtended<Account[]>,
+  ): AsyncGenerator<AxiosResponse<Pick<Account, F>[]>>;
+  listByPage(options: OptionsExtended<Account>): AsyncGenerator<AxiosResponse<Account[]>>;
   listByPage(options?: Options) {
-    return super.iterator<Account>({ url: this.apiPath }, options).byPage();
+    return super.iterator({ url: this.apiPath }, options).byPage();
   }
 }

--- a/src/services/attendance.service.ts
+++ b/src/services/attendance.service.ts
@@ -54,7 +54,7 @@ export class AttendanceService extends Service<Attendance> {
     options: { fields: F[] } & OptionsExtended<Attendance[]>,
   ): Promise<Pick<Attendance, F>[]>;
   listAll(query: AttendanceQueryParams, options?: OptionsExtended<Attendance[]>): Promise<Attendance[]>;
-  async listAll(query: AttendanceQueryParams, options?: Options) {
+  async listAll(query: AttendanceQueryParams, options?: OptionsExtended<Attendance[]>) {
     const attendance = [] as Attendance[];
     for await (const atten of this.list(query, options)) {
       attendance.push(atten);
@@ -69,9 +69,9 @@ export class AttendanceService extends Service<Attendance> {
   ): AsyncGenerator<AxiosResponse<Pick<Attendance, F>[]>>;
   listByPage(
     query: AttendanceQueryParams,
-    options?: OptionsExtended<Attendance>,
+    options?: OptionsExtended<Attendance[]>,
   ): AsyncGenerator<AxiosResponse<Attendance[]>>;
-  listByPage(query: AttendanceQueryParams, options?: Options) {
+  listByPage(query: AttendanceQueryParams, options?: OptionsExtended<Attendance[]>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/attendance.service.ts
+++ b/src/services/attendance.service.ts
@@ -38,23 +38,23 @@ export class AttendanceService extends Service<Attendance> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query?: AttendanceQueryParams): AsyncGenerator<Attendance>;
+  list(query: AttendanceQueryParams): AsyncGenerator<Attendance>;
   list<F extends keyof Attendance>(
     query: AttendanceQueryParams,
     options: { fields: F[] } & OptionsExtended<Attendance>,
   ): AsyncGenerator<Pick<Attendance, F>>;
-  list(query?: AttendanceQueryParams, options?: OptionsExtended<Attendance>): AsyncGenerator<Attendance>;
-  async *list(query?: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
+  list(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>): AsyncGenerator<Attendance>;
+  async *list(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query?: AttendanceQueryParams): Promise<Attendance[]>;
+  listAll(query: AttendanceQueryParams): Promise<Attendance[]>;
   listAll<F extends keyof Attendance>(
     query: AttendanceQueryParams,
     options: { fields: F[] } & OptionsExtended<Attendance>,
   ): Promise<Pick<Attendance, F>[]>;
-  listAll(query?: AttendanceQueryParams, options?: OptionsExtended<Attendance>): Promise<Attendance[]>;
-  async listAll(query?: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
+  listAll(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>): Promise<Attendance[]>;
+  async listAll(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
     const attendance = [] as Attendance[];
     for await (const atten of this.list(query, options)) {
       attendance.push(atten);
@@ -62,7 +62,7 @@ export class AttendanceService extends Service<Attendance> {
     return attendance;
   }
 
-  listByPage(query?: AttendanceQueryParams): AsyncGenerator<AxiosResponse<Attendance[]>>;
+  listByPage(query: AttendanceQueryParams): AsyncGenerator<AxiosResponse<Attendance[]>>;
   listByPage<F extends keyof Attendance>(
     query: AttendanceQueryParams,
     options: { fields: F[] } & OptionsExtended<Attendance>,
@@ -71,7 +71,7 @@ export class AttendanceService extends Service<Attendance> {
     query: AttendanceQueryParams,
     options?: OptionsExtended<Attendance>,
   ): AsyncGenerator<AxiosResponse<Attendance[]>>;
-  listByPage(query?: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
+  listByPage(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/attendance.service.ts
+++ b/src/services/attendance.service.ts
@@ -96,11 +96,11 @@ export class AttendanceService extends Service<Attendance> {
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   delete(id: number, options?: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .fetch<void>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/attendance.service.ts
+++ b/src/services/attendance.service.ts
@@ -51,10 +51,10 @@ export class AttendanceService extends Service<Attendance> {
   listAll(query: AttendanceQueryParams): Promise<Attendance[]>;
   listAll<F extends keyof Attendance>(
     query: AttendanceQueryParams,
-    options: { fields: F[] } & OptionsExtended<Attendance[]>,
+    options: { fields: F[] } & OptionsExtended<Attendance>,
   ): Promise<Pick<Attendance, F>[]>;
-  listAll(query: AttendanceQueryParams, options?: OptionsExtended<Attendance[]>): Promise<Attendance[]>;
-  async listAll(query: AttendanceQueryParams, options?: OptionsExtended<Attendance[]>) {
+  listAll(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>): Promise<Attendance[]>;
+  async listAll(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
     const attendance = [] as Attendance[];
     for await (const atten of this.list(query, options)) {
       attendance.push(atten);
@@ -65,13 +65,13 @@ export class AttendanceService extends Service<Attendance> {
   listByPage(query: AttendanceQueryParams): AsyncGenerator<AxiosResponse<Attendance[]>>;
   listByPage<F extends keyof Attendance>(
     query: AttendanceQueryParams,
-    options: { fields: F[] } & OptionsExtended<Attendance[]>,
+    options: { fields: F[] } & OptionsExtended<Attendance>,
   ): AsyncGenerator<AxiosResponse<Pick<Attendance, F>[]>>;
   listByPage(
     query: AttendanceQueryParams,
-    options?: OptionsExtended<Attendance[]>,
+    options?: OptionsExtended<Attendance>,
   ): AsyncGenerator<AxiosResponse<Attendance[]>>;
-  listByPage(query: AttendanceQueryParams, options?: OptionsExtended<Attendance[]>) {
+  listByPage(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/attendance.service.ts
+++ b/src/services/attendance.service.ts
@@ -43,7 +43,7 @@ export class AttendanceService extends Service<Attendance> {
     query: AttendanceQueryParams,
     options: { fields: F[] } & OptionsExtended<Attendance>,
   ): AsyncGenerator<Pick<Attendance, F>>;
-  list(query: AttendanceQueryParams, options?: Options): AsyncGenerator<Attendance>;
+  list(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>): AsyncGenerator<Attendance>;
   async *list(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }

--- a/src/services/attendance.service.ts
+++ b/src/services/attendance.service.ts
@@ -38,23 +38,23 @@ export class AttendanceService extends Service<Attendance> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query: AttendanceQueryParams): AsyncGenerator<Attendance>;
+  list(query?: AttendanceQueryParams): AsyncGenerator<Attendance>;
   list<F extends keyof Attendance>(
     query: AttendanceQueryParams,
     options: { fields: F[] } & OptionsExtended<Attendance>,
   ): AsyncGenerator<Pick<Attendance, F>>;
-  list(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>): AsyncGenerator<Attendance>;
-  async *list(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
+  list(query?: AttendanceQueryParams, options?: OptionsExtended<Attendance>): AsyncGenerator<Attendance>;
+  async *list(query?: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: AttendanceQueryParams): Promise<Attendance[]>;
+  listAll(query?: AttendanceQueryParams): Promise<Attendance[]>;
   listAll<F extends keyof Attendance>(
     query: AttendanceQueryParams,
     options: { fields: F[] } & OptionsExtended<Attendance>,
   ): Promise<Pick<Attendance, F>[]>;
-  listAll(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>): Promise<Attendance[]>;
-  async listAll(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
+  listAll(query?: AttendanceQueryParams, options?: OptionsExtended<Attendance>): Promise<Attendance[]>;
+  async listAll(query?: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
     const attendance = [] as Attendance[];
     for await (const atten of this.list(query, options)) {
       attendance.push(atten);
@@ -62,7 +62,7 @@ export class AttendanceService extends Service<Attendance> {
     return attendance;
   }
 
-  listByPage(query: AttendanceQueryParams): AsyncGenerator<AxiosResponse<Attendance[]>>;
+  listByPage(query?: AttendanceQueryParams): AsyncGenerator<AxiosResponse<Attendance[]>>;
   listByPage<F extends keyof Attendance>(
     query: AttendanceQueryParams,
     options: { fields: F[] } & OptionsExtended<Attendance>,
@@ -71,7 +71,7 @@ export class AttendanceService extends Service<Attendance> {
     query: AttendanceQueryParams,
     options?: OptionsExtended<Attendance>,
   ): AsyncGenerator<AxiosResponse<Attendance[]>>;
-  listByPage(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
+  listByPage(query?: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/attendance.service.ts
+++ b/src/services/attendance.service.ts
@@ -1,42 +1,59 @@
 import { AxiosResponse } from 'axios';
 import { Attendance } from '../interfaces/index.js';
-import { Service, Options, RequirementsOf } from './index.js';
+import { Service, Options, RequirementsOf, OptionsExtended } from './index.js';
 
 import { AttendanceQueryParams } from '../interfaces/query-params/attendance-query-params.interface.js';
 
 type RequiredProps = 'user' | 'in_time';
 
-export class AttendanceService extends Service {
+export class AttendanceService extends Service<Attendance> {
   private apiPath = '/attendance';
 
   create(data: RequirementsOf<Attendance, RequiredProps>): Promise<Attendance>;
   create(
     data: RequirementsOf<Attendance, RequiredProps>,
     options: { rawResponse: true } & Options,
-  ): Promise<AxiosResponse<Attendance, any>>;
+  ): Promise<AxiosResponse<Attendance>>;
   create(data: RequirementsOf<Attendance, RequiredProps>, options: Options): Promise<Attendance>;
   create(data: RequirementsOf<Attendance, RequiredProps>, options?: Options) {
     return super
-      .fetch<Attendance>({ url: this.apiPath, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<Attendance>({ url: this.apiPath, data, method: 'POST' }, options)
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   get(id: number): Promise<Attendance>;
-  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<Attendance, any>>;
-  get(id: number, options: Options): Promise<Attendance>;
-  get(id: number, options?: Options) {
+  get<F extends keyof Attendance>(
+    id: number,
+    options: { fields: F[]; rawResponse: true } & OptionsExtended<Attendance>,
+  ): Promise<AxiosResponse<Pick<Attendance, F>>>;
+  get<F extends keyof Attendance>(
+    id: number,
+    options: { fields: F[] } & OptionsExtended<Attendance>,
+  ): Promise<Pick<Attendance, F>>;
+  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<Attendance>>;
+  get(id: number, options?: OptionsExtended<Attendance>): Promise<Attendance>;
+  get(id: number, options?: OptionsExtended<Attendance>) {
     return super
       .fetch<Attendance>({ url: `${this.apiPath}/${id}` }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
+  list(query: AttendanceQueryParams): AsyncGenerator<Attendance>;
+  list<F extends keyof Attendance>(
+    query: AttendanceQueryParams,
+    options: { fields: F[] } & OptionsExtended<Attendance>,
+  ): AsyncGenerator<Pick<Attendance, F>>;
+  list(query: AttendanceQueryParams, options?: Options): AsyncGenerator<Attendance>;
   async *list(query: AttendanceQueryParams, options?: Options) {
-    for await (const res of super.iterator<Attendance>({ url: this.apiPath, params: query }, options)) {
-      yield res;
-    }
+    yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: AttendanceQueryParams, options?: Options): Promise<Attendance[]>;
+  listAll(query: AttendanceQueryParams): Promise<Attendance[]>;
+  listAll<F extends keyof Attendance>(
+    query: AttendanceQueryParams,
+    options: { fields: F[] } & OptionsExtended<Attendance[]>,
+  ): Promise<Pick<Attendance, F>[]>;
+  listAll(query: AttendanceQueryParams, options?: OptionsExtended<Attendance[]>): Promise<Attendance[]>;
   async listAll(query: AttendanceQueryParams, options?: Options) {
     const attendance = [] as Attendance[];
     for await (const atten of this.list(query, options)) {
@@ -45,8 +62,17 @@ export class AttendanceService extends Service {
     return attendance;
   }
 
+  listByPage(query: AttendanceQueryParams): AsyncGenerator<AxiosResponse<Attendance[]>>;
+  listByPage<F extends keyof Attendance>(
+    query: AttendanceQueryParams,
+    options: { fields: F[] } & OptionsExtended<Attendance[]>,
+  ): AsyncGenerator<AxiosResponse<Pick<Attendance, F>[]>>;
+  listByPage(
+    query: AttendanceQueryParams,
+    options?: OptionsExtended<Attendance>,
+  ): AsyncGenerator<AxiosResponse<Attendance[]>>;
   listByPage(query: AttendanceQueryParams, options?: Options) {
-    return super.iterator<Attendance>({ url: this.apiPath, params: query }, options).byPage();
+    return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 
   update(id: number, data: Partial<Attendance>): Promise<Attendance>;
@@ -54,24 +80,27 @@ export class AttendanceService extends Service {
     id: number,
     data: Partial<Attendance>,
     options: { rawResponse: true } & Options,
-  ): Promise<AxiosResponse<Attendance, any>>;
+  ): Promise<AxiosResponse<Attendance>>;
   update(id: number, data: Partial<Attendance>, options: Options): Promise<Attendance>;
   update(id: number, data: Partial<Attendance>, options?: Options) {
     return super
-      .fetch<Attendance>({
-        url: `${this.apiPath}/${id}`,
-        data,
-        method: 'POST',
-      })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<Attendance>(
+        {
+          url: `${this.apiPath}/${id}`,
+          data,
+          method: 'POST',
+        },
+        options,
+      )
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<Attendance, any>>;
-  delete(id: number, options: Options): Promise<number>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  delete(id: number, options?: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<Attendance>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/attendance.service.ts
+++ b/src/services/attendance.service.ts
@@ -44,7 +44,7 @@ export class AttendanceService extends Service<Attendance> {
     options: { fields: F[] } & OptionsExtended<Attendance>,
   ): AsyncGenerator<Pick<Attendance, F>>;
   list(query: AttendanceQueryParams, options?: Options): AsyncGenerator<Attendance>;
-  async *list(query: AttendanceQueryParams, options?: Options) {
+  async *list(query: AttendanceQueryParams, options?: OptionsExtended<Attendance>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -8,8 +8,6 @@ export class AuthService extends Service {
   get(options?: { rawResponse: true } & Options): Promise<AxiosResponse<Auth, any>>;
   get(options?: Options): Promise<Auth>;
   get(options?: Options) {
-    return super
-      .fetch<Auth>({ url: this.apiPath }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+    return super.fetch<Auth>({ url: this.apiPath }, options).then((res) => (options?.rawResponse ? res : res.data));
   }
 }

--- a/src/services/availability.service.ts
+++ b/src/services/availability.service.ts
@@ -48,11 +48,11 @@ export class AvailabilityService extends Service<Availability> {
     );
   }
 
-  async *list(query: AvailabilityQueryParams, options?: Options) {
+  async *list(query?: AvailabilityQueryParams, options?: Options) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listByPage(query: AvailabilityQueryParams, options?: Options) {
+  listByPage(query?: AvailabilityQueryParams, options?: Options) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 }

--- a/src/services/availability.service.ts
+++ b/src/services/availability.service.ts
@@ -4,7 +4,7 @@ import { Service, Options } from './index.js';
 import { AvailabilityQueryParams } from '../interfaces/query-params/availability-query-params.interface.js';
 import { Availability } from '../interfaces/availability.interface.js';
 
-export class AvailabilityService extends Service {
+export class AvailabilityService extends Service<Availability> {
   private apiPath = '/availability';
 
   update(data: Availability): Promise<Availability>;
@@ -12,12 +12,15 @@ export class AvailabilityService extends Service {
   update(data: Availability, options?: Options): Promise<Availability | AxiosResponse<Availability>>;
   update(data: Availability, options?: Options) {
     return super
-      .fetch<Availability>({
-        url: this.apiPath,
-        data,
-        method: 'POST',
-      })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<Availability>(
+        {
+          url: this.apiPath,
+          data,
+          method: 'POST',
+        },
+        options,
+      )
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   /** Alias of {@link AvailabilityService["update"]} */
@@ -46,12 +49,10 @@ export class AvailabilityService extends Service {
   }
 
   async *list(query: AvailabilityQueryParams, options?: Options) {
-    for await (const res of super.iterator<Availability>({ url: this.apiPath, params: query }, options)) {
-      yield res;
-    }
+    yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
   listByPage(query: AvailabilityQueryParams, options?: Options) {
-    return super.iterator<Availability>({ url: this.apiPath, params: query }, options).byPage();
+    return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 }

--- a/src/services/daily-budgets.service.ts
+++ b/src/services/daily-budgets.service.ts
@@ -7,23 +7,23 @@ import { DailyBudgetsQueryParams } from '../interfaces/query-params/daily-budget
 export class DailyBudgetsService extends Service<DailyBudgets> {
   private apiPath = '/daily_budgets';
 
-  list(query?: DailyBudgetsQueryParams): AsyncGenerator<DailyBudgets>;
+  list(query: DailyBudgetsQueryParams): AsyncGenerator<DailyBudgets>;
   list<F extends keyof DailyBudgets>(
     query: DailyBudgetsQueryParams,
     options: { fields: F[] } & OptionsExtended<DailyBudgets>,
   ): AsyncGenerator<Pick<DailyBudgets, F>>;
-  list(query?: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>): AsyncGenerator<DailyBudgets>;
-  async *list(query?: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
+  list(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>): AsyncGenerator<DailyBudgets>;
+  async *list(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query?: DailyBudgetsQueryParams): Promise<DailyBudgets[]>;
+  listAll(query: DailyBudgetsQueryParams): Promise<DailyBudgets[]>;
   listAll<F extends keyof DailyBudgets>(
     query: DailyBudgetsQueryParams,
     options: { fields: F[] } & OptionsExtended<DailyBudgets>,
   ): Promise<Pick<DailyBudgets, F>[]>;
-  listAll(query?: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>): Promise<DailyBudgets[]>;
-  async listAll(query?: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
+  listAll(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>): Promise<DailyBudgets[]>;
+  async listAll(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
     const attendance = [] as DailyBudgets[];
     for await (const atten of this.list(query, options)) {
       attendance.push(atten);
@@ -31,7 +31,7 @@ export class DailyBudgetsService extends Service<DailyBudgets> {
     return attendance;
   }
 
-  listByPage(query?: DailyBudgetsQueryParams): AsyncGenerator<AxiosResponse<DailyBudgets[]>>;
+  listByPage(query: DailyBudgetsQueryParams): AsyncGenerator<AxiosResponse<DailyBudgets[]>>;
   listByPage<F extends keyof DailyBudgets>(
     query: DailyBudgetsQueryParams,
     options: { fields: F[] } & OptionsExtended<DailyBudgets>,
@@ -40,7 +40,7 @@ export class DailyBudgetsService extends Service<DailyBudgets> {
     query: DailyBudgetsQueryParams,
     options?: OptionsExtended<DailyBudgets>,
   ): AsyncGenerator<AxiosResponse<DailyBudgets[]>>;
-  listByPage(query?: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
+  listByPage(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/daily-budgets.service.ts
+++ b/src/services/daily-budgets.service.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { DailyBudgets } from '../interfaces/daily-budgets.interface.js';
-import { Service, Options, OptionsExtended } from './index.js';
+import { Service, OptionsExtended } from './index.js';
 
 import { DailyBudgetsQueryParams } from '../interfaces/query-params/daily-budgets-query-params.interface.js';
 
@@ -12,8 +12,8 @@ export class DailyBudgetsService extends Service<DailyBudgets> {
     query: DailyBudgetsQueryParams,
     options: { fields: F[] } & OptionsExtended<DailyBudgets>,
   ): AsyncGenerator<Pick<DailyBudgets, F>>;
-  list(query: DailyBudgetsQueryParams, options?: Options): AsyncGenerator<DailyBudgets>;
-  async *list(query: DailyBudgetsQueryParams, options?: Options) {
+  list(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>): AsyncGenerator<DailyBudgets>;
+  async *list(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
@@ -23,7 +23,7 @@ export class DailyBudgetsService extends Service<DailyBudgets> {
     options: { fields: F[] } & OptionsExtended<DailyBudgets>,
   ): Promise<Pick<DailyBudgets, F>[]>;
   listAll(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>): Promise<DailyBudgets[]>;
-  async listAll(query: DailyBudgetsQueryParams, options?: Options) {
+  async listAll(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
     const attendance = [] as DailyBudgets[];
     for await (const atten of this.list(query, options)) {
       attendance.push(atten);

--- a/src/services/daily-budgets.service.ts
+++ b/src/services/daily-budgets.service.ts
@@ -7,23 +7,23 @@ import { DailyBudgetsQueryParams } from '../interfaces/query-params/daily-budget
 export class DailyBudgetsService extends Service<DailyBudgets> {
   private apiPath = '/daily_budgets';
 
-  list(query: DailyBudgetsQueryParams): AsyncGenerator<DailyBudgets>;
+  list(query?: DailyBudgetsQueryParams): AsyncGenerator<DailyBudgets>;
   list<F extends keyof DailyBudgets>(
     query: DailyBudgetsQueryParams,
     options: { fields: F[] } & OptionsExtended<DailyBudgets>,
   ): AsyncGenerator<Pick<DailyBudgets, F>>;
-  list(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>): AsyncGenerator<DailyBudgets>;
-  async *list(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
+  list(query?: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>): AsyncGenerator<DailyBudgets>;
+  async *list(query?: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: DailyBudgetsQueryParams): Promise<DailyBudgets[]>;
+  listAll(query?: DailyBudgetsQueryParams): Promise<DailyBudgets[]>;
   listAll<F extends keyof DailyBudgets>(
     query: DailyBudgetsQueryParams,
     options: { fields: F[] } & OptionsExtended<DailyBudgets>,
   ): Promise<Pick<DailyBudgets, F>[]>;
-  listAll(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>): Promise<DailyBudgets[]>;
-  async listAll(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
+  listAll(query?: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>): Promise<DailyBudgets[]>;
+  async listAll(query?: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
     const attendance = [] as DailyBudgets[];
     for await (const atten of this.list(query, options)) {
       attendance.push(atten);
@@ -31,7 +31,7 @@ export class DailyBudgetsService extends Service<DailyBudgets> {
     return attendance;
   }
 
-  listByPage(query: DailyBudgetsQueryParams): AsyncGenerator<AxiosResponse<DailyBudgets[]>>;
+  listByPage(query?: DailyBudgetsQueryParams): AsyncGenerator<AxiosResponse<DailyBudgets[]>>;
   listByPage<F extends keyof DailyBudgets>(
     query: DailyBudgetsQueryParams,
     options: { fields: F[] } & OptionsExtended<DailyBudgets>,
@@ -40,7 +40,7 @@ export class DailyBudgetsService extends Service<DailyBudgets> {
     query: DailyBudgetsQueryParams,
     options?: OptionsExtended<DailyBudgets>,
   ): AsyncGenerator<AxiosResponse<DailyBudgets[]>>;
-  listByPage(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
+  listByPage(query?: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/daily-budgets.service.ts
+++ b/src/services/daily-budgets.service.ts
@@ -1,19 +1,28 @@
 import { AxiosResponse } from 'axios';
 import { DailyBudgets } from '../interfaces/daily-budgets.interface.js';
-import { Service, Options } from './index.js';
+import { Service, Options, OptionsExtended } from './index.js';
 
 import { DailyBudgetsQueryParams } from '../interfaces/query-params/daily-budgets-query-params.interface.js';
 
-export class DailyBudgetsService extends Service {
+export class DailyBudgetsService extends Service<DailyBudgets> {
   private apiPath = '/daily_budgets';
 
+  list(query: DailyBudgetsQueryParams): AsyncGenerator<DailyBudgets>;
+  list<F extends keyof DailyBudgets>(
+    query: DailyBudgetsQueryParams,
+    options: { fields: F[] } & OptionsExtended<DailyBudgets>,
+  ): AsyncGenerator<Pick<DailyBudgets, F>>;
+  list(query: DailyBudgetsQueryParams, options?: Options): AsyncGenerator<DailyBudgets>;
   async *list(query: DailyBudgetsQueryParams, options?: Options) {
-    for await (const res of super.iterator<DailyBudgets>({ url: this.apiPath, params: query }, options)) {
-      yield res;
-    }
+    yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: DailyBudgetsQueryParams, options?: Options): Promise<DailyBudgets[]>;
+  listAll(query: DailyBudgetsQueryParams): Promise<DailyBudgets[]>;
+  listAll<F extends keyof DailyBudgets>(
+    query: DailyBudgetsQueryParams,
+    options: { fields: F[] } & OptionsExtended<DailyBudgets[]>,
+  ): Promise<Pick<DailyBudgets, F>[]>;
+  listAll(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>): Promise<DailyBudgets[]>;
   async listAll(query: DailyBudgetsQueryParams, options?: Options) {
     const attendance = [] as DailyBudgets[];
     for await (const atten of this.list(query, options)) {
@@ -22,23 +31,35 @@ export class DailyBudgetsService extends Service {
     return attendance;
   }
 
-  listByPage(query: DailyBudgetsQueryParams, options?: Options) {
-    return super.iterator<DailyBudgets>({ url: this.apiPath, params: query }, options).byPage();
+  listByPage(query: DailyBudgetsQueryParams): AsyncGenerator<AxiosResponse<DailyBudgets[]>>;
+  listByPage<F extends keyof DailyBudgets>(
+    query: DailyBudgetsQueryParams,
+    options: { fields: F[] } & OptionsExtended<DailyBudgets[]>,
+  ): AsyncGenerator<AxiosResponse<Pick<DailyBudgets, F>[]>>;
+  listByPage(
+    query: DailyBudgetsQueryParams,
+    options?: OptionsExtended<DailyBudgets>,
+  ): AsyncGenerator<AxiosResponse<DailyBudgets[]>>;
+  listByPage(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>) {
+    return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 
   update(data: Partial<DailyBudgets>[]): Promise<number>;
   update(
     data: Partial<DailyBudgets>[],
-    options: { rawResponse: true } & Options,
-  ): Promise<AxiosResponse<DailyBudgets, any>>;
-  update(data: Partial<DailyBudgets>[], options: Options): Promise<number>;
-  update(data: Partial<DailyBudgets>[], options?: Options) {
+    options: { rawResponse: true } & OptionsExtended<DailyBudgets>,
+  ): Promise<AxiosResponse<number>>;
+  update(data: Partial<DailyBudgets>[], options?: OptionsExtended<DailyBudgets>): Promise<number>;
+  update(data: Partial<DailyBudgets>[], options?: OptionsExtended<DailyBudgets>) {
     return super
-      .fetch<DailyBudgets>({
-        url: `${this.apiPath}`,
-        data,
-        method: 'POST',
-      })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+      .fetch<number>(
+        {
+          url: this.apiPath,
+          data,
+          method: 'POST',
+        },
+        options,
+      )
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/daily-budgets.service.ts
+++ b/src/services/daily-budgets.service.ts
@@ -20,7 +20,7 @@ export class DailyBudgetsService extends Service<DailyBudgets> {
   listAll(query: DailyBudgetsQueryParams): Promise<DailyBudgets[]>;
   listAll<F extends keyof DailyBudgets>(
     query: DailyBudgetsQueryParams,
-    options: { fields: F[] } & OptionsExtended<DailyBudgets[]>,
+    options: { fields: F[] } & OptionsExtended<DailyBudgets>,
   ): Promise<Pick<DailyBudgets, F>[]>;
   listAll(query: DailyBudgetsQueryParams, options?: OptionsExtended<DailyBudgets>): Promise<DailyBudgets[]>;
   async listAll(query: DailyBudgetsQueryParams, options?: Options) {
@@ -34,7 +34,7 @@ export class DailyBudgetsService extends Service<DailyBudgets> {
   listByPage(query: DailyBudgetsQueryParams): AsyncGenerator<AxiosResponse<DailyBudgets[]>>;
   listByPage<F extends keyof DailyBudgets>(
     query: DailyBudgetsQueryParams,
-    options: { fields: F[] } & OptionsExtended<DailyBudgets[]>,
+    options: { fields: F[] } & OptionsExtended<DailyBudgets>,
   ): AsyncGenerator<AxiosResponse<Pick<DailyBudgets, F>[]>>;
   listByPage(
     query: DailyBudgetsQueryParams,
@@ -48,11 +48,11 @@ export class DailyBudgetsService extends Service<DailyBudgets> {
   update(
     data: Partial<DailyBudgets>[],
     options: { rawResponse: true } & OptionsExtended<DailyBudgets>,
-  ): Promise<AxiosResponse<number>>;
+  ): Promise<AxiosResponse<void>>;
   update(data: Partial<DailyBudgets>[], options?: OptionsExtended<DailyBudgets>): Promise<number>;
   update(data: Partial<DailyBudgets>[], options?: OptionsExtended<DailyBudgets>) {
     return super
-      .fetch<number>(
+      .fetch<void>(
         {
           url: this.apiPath,
           data,

--- a/src/services/daily-revenue.service.ts
+++ b/src/services/daily-revenue.service.ts
@@ -20,7 +20,7 @@ export class DailyRevenueService extends Service<DailyRevenue> {
   listAll(query: DailyRevenueQueryParams): Promise<DailyRevenue[]>;
   listAll<F extends keyof DailyRevenue>(
     query: DailyRevenueQueryParams,
-    options: { fields: F[] } & OptionsExtended<DailyRevenue[]>,
+    options: { fields: F[] } & OptionsExtended<DailyRevenue>,
   ): Promise<Pick<DailyRevenue, F>[]>;
   listAll(query: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>): Promise<DailyRevenue[]>;
   async listAll(query: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>) {
@@ -34,7 +34,7 @@ export class DailyRevenueService extends Service<DailyRevenue> {
   listByPage(query: DailyRevenueQueryParams): AsyncGenerator<AxiosResponse<DailyRevenue[]>>;
   listByPage<F extends keyof DailyRevenue>(
     query: DailyRevenueQueryParams,
-    options: { fields: F[] } & OptionsExtended<DailyRevenue[]>,
+    options: { fields: F[] } & OptionsExtended<DailyRevenue>,
   ): AsyncGenerator<AxiosResponse<Pick<DailyRevenue, F>[]>>;
   listByPage(
     query: DailyRevenueQueryParams,
@@ -45,11 +45,11 @@ export class DailyRevenueService extends Service<DailyRevenue> {
   }
 
   update(data: Partial<DailyRevenue>[]): Promise<number>;
-  update(data: Partial<DailyRevenue>[], options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  update(data: Partial<DailyRevenue>[], options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   update(data: Partial<DailyRevenue>[], options: Options): Promise<number>;
   update(data: Partial<DailyRevenue>[], options?: Options) {
     return super
-      .fetch<number>(
+      .fetch<void>(
         {
           url: `${this.apiPath}`,
           data,

--- a/src/services/daily-revenue.service.ts
+++ b/src/services/daily-revenue.service.ts
@@ -7,23 +7,23 @@ import { DailyRevenueQueryParams } from '../interfaces/query-params/daily-revenu
 export class DailyRevenueService extends Service<DailyRevenue> {
   private apiPath = '/daily_revenue';
 
-  list(query: DailyRevenueQueryParams): AsyncGenerator<DailyRevenue>;
+  list(query?: DailyRevenueQueryParams): AsyncGenerator<DailyRevenue>;
   list<F extends keyof DailyRevenue>(
     query: DailyRevenueQueryParams,
     options: { fields: F[] } & OptionsExtended<DailyRevenue>,
   ): AsyncGenerator<Pick<DailyRevenue, F>>;
-  list(query: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>): AsyncGenerator<DailyRevenue>;
-  async *list(query: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>) {
+  list(query?: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>): AsyncGenerator<DailyRevenue>;
+  async *list(query?: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>) {
     yield* super.iterator<DailyRevenue>({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: DailyRevenueQueryParams): Promise<DailyRevenue[]>;
+  listAll(query?: DailyRevenueQueryParams): Promise<DailyRevenue[]>;
   listAll<F extends keyof DailyRevenue>(
     query: DailyRevenueQueryParams,
     options: { fields: F[] } & OptionsExtended<DailyRevenue>,
   ): Promise<Pick<DailyRevenue, F>[]>;
-  listAll(query: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>): Promise<DailyRevenue[]>;
-  async listAll(query: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>) {
+  listAll(query?: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>): Promise<DailyRevenue[]>;
+  async listAll(query?: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>) {
     const attendance = [] as DailyRevenue[];
     for await (const atten of this.list(query, options)) {
       attendance.push(atten);
@@ -31,7 +31,7 @@ export class DailyRevenueService extends Service<DailyRevenue> {
     return attendance;
   }
 
-  listByPage(query: DailyRevenueQueryParams): AsyncGenerator<AxiosResponse<DailyRevenue[]>>;
+  listByPage(query?: DailyRevenueQueryParams): AsyncGenerator<AxiosResponse<DailyRevenue[]>>;
   listByPage<F extends keyof DailyRevenue>(
     query: DailyRevenueQueryParams,
     options: { fields: F[] } & OptionsExtended<DailyRevenue>,
@@ -40,7 +40,7 @@ export class DailyRevenueService extends Service<DailyRevenue> {
     query: DailyRevenueQueryParams,
     options?: OptionsExtended<DailyRevenue>,
   ): AsyncGenerator<AxiosResponse<DailyRevenue[]>>;
-  listByPage(query: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>) {
+  listByPage(query?: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>) {
     return super.iterator<DailyRevenue>({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/daily-revenue.service.ts
+++ b/src/services/daily-revenue.service.ts
@@ -1,20 +1,29 @@
 import { AxiosResponse } from 'axios';
 import { DailyRevenue } from '../interfaces/daily-revenue.interface.js';
-import { Service, Options } from './index.js';
+import { Service, Options, OptionsExtended } from './index.js';
 
 import { DailyRevenueQueryParams } from '../interfaces/query-params/daily-revenue-query-params.interface.js';
 
-export class DailyRevenueService extends Service {
+export class DailyRevenueService extends Service<DailyRevenue> {
   private apiPath = '/daily_revenue';
 
-  async *list(query: DailyRevenueQueryParams, options?: Options) {
-    for await (const res of super.iterator<DailyRevenue>({ url: this.apiPath, params: query }, options)) {
-      yield res;
-    }
+  list(query: DailyRevenueQueryParams): AsyncGenerator<DailyRevenue>;
+  list<F extends keyof DailyRevenue>(
+    query: DailyRevenueQueryParams,
+    options: { fields: F[] } & OptionsExtended<DailyRevenue>,
+  ): AsyncGenerator<Pick<DailyRevenue, F>>;
+  list(query: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>): AsyncGenerator<DailyRevenue>;
+  async *list(query: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>) {
+    yield* super.iterator<DailyRevenue>({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: DailyRevenueQueryParams, options?: Options): Promise<DailyRevenue[]>;
-  async listAll(query: DailyRevenueQueryParams, options?: Options) {
+  listAll(query: DailyRevenueQueryParams): Promise<DailyRevenue[]>;
+  listAll<F extends keyof DailyRevenue>(
+    query: DailyRevenueQueryParams,
+    options: { fields: F[] } & OptionsExtended<DailyRevenue[]>,
+  ): Promise<Pick<DailyRevenue, F>[]>;
+  listAll(query: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>): Promise<DailyRevenue[]>;
+  async listAll(query: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>) {
     const attendance = [] as DailyRevenue[];
     for await (const atten of this.list(query, options)) {
       attendance.push(atten);
@@ -22,23 +31,32 @@ export class DailyRevenueService extends Service {
     return attendance;
   }
 
-  listByPage(query: DailyRevenueQueryParams, options?: Options) {
+  listByPage(query: DailyRevenueQueryParams): AsyncGenerator<AxiosResponse<DailyRevenue[]>>;
+  listByPage<F extends keyof DailyRevenue>(
+    query: DailyRevenueQueryParams,
+    options: { fields: F[] } & OptionsExtended<DailyRevenue[]>,
+  ): AsyncGenerator<AxiosResponse<Pick<DailyRevenue, F>[]>>;
+  listByPage(
+    query: DailyRevenueQueryParams,
+    options?: OptionsExtended<DailyRevenue>,
+  ): AsyncGenerator<AxiosResponse<DailyRevenue[]>>;
+  listByPage(query: DailyRevenueQueryParams, options?: OptionsExtended<DailyRevenue>) {
     return super.iterator<DailyRevenue>({ url: this.apiPath, params: query }, options).byPage();
   }
 
   update(data: Partial<DailyRevenue>[]): Promise<number>;
-  update(
-    data: Partial<DailyRevenue>[],
-    options: { rawResponse: true } & Options,
-  ): Promise<AxiosResponse<DailyRevenue, any>>;
+  update(data: Partial<DailyRevenue>[], options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
   update(data: Partial<DailyRevenue>[], options: Options): Promise<number>;
   update(data: Partial<DailyRevenue>[], options?: Options) {
     return super
-      .fetch<DailyRevenue>({
-        url: `${this.apiPath}`,
-        data,
-        method: 'POST',
-      })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+      .fetch<number>(
+        {
+          url: `${this.apiPath}`,
+          data,
+          method: 'POST',
+        },
+        options,
+      )
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/day-notes.service.ts
+++ b/src/services/day-notes.service.ts
@@ -46,9 +46,8 @@ export class DayNotesService extends Service<DayNote> {
   listAll(query: DayNotesQueryParams): Promise<DayNote[]>;
   listAll<F extends keyof DayNote>(
     query: DayNotesQueryParams,
-    options: { fields: F[] } & OptionsExtended<DayNote[]>,
+    options: { fields: F[] } & OptionsExtended<DayNote>,
   ): Promise<Pick<DayNote, F>[]>;
-  listAll(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>): Promise<DayNote[]>;
   listAll(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>): Promise<DayNote[]>;
   async listAll(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
     const dayNotes: DayNote[] = [];
@@ -61,7 +60,7 @@ export class DayNotesService extends Service<DayNote> {
   listByPage(query: DayNotesQueryParams): AsyncGenerator<AxiosResponse<DayNote[]>>;
   listByPage<F extends keyof DayNote>(
     query: DayNotesQueryParams,
-    options: { fields: F[] } & OptionsExtended<DayNote[]>,
+    options: { fields: F[] } & OptionsExtended<DayNote>,
   ): AsyncGenerator<AxiosResponse<Pick<DayNote, F>[]>>;
   listByPage(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>): AsyncGenerator<AxiosResponse<DayNote[]>>;
   listByPage(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {

--- a/src/services/day-notes.service.ts
+++ b/src/services/day-notes.service.ts
@@ -33,23 +33,23 @@ export class DayNotesService extends Service<DayNote> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query: DayNotesQueryParams): AsyncGenerator<DayNote>;
+  list(query?: DayNotesQueryParams): AsyncGenerator<DayNote>;
   list<F extends keyof DayNote>(
     query: DayNotesQueryParams,
     options: { fields: F[] } & OptionsExtended<DayNote>,
   ): AsyncGenerator<Pick<DayNote, F>>;
-  list(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>): AsyncGenerator<DayNote>;
-  async *list(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
+  list(query?: DayNotesQueryParams, options?: OptionsExtended<DayNote>): AsyncGenerator<DayNote>;
+  async *list(query?: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: DayNotesQueryParams): Promise<DayNote[]>;
+  listAll(query?: DayNotesQueryParams): Promise<DayNote[]>;
   listAll<F extends keyof DayNote>(
     query: DayNotesQueryParams,
     options: { fields: F[] } & OptionsExtended<DayNote>,
   ): Promise<Pick<DayNote, F>[]>;
-  listAll(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>): Promise<DayNote[]>;
-  async listAll(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
+  listAll(query?: DayNotesQueryParams, options?: OptionsExtended<DayNote>): Promise<DayNote[]>;
+  async listAll(query?: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
     const dayNotes: DayNote[] = [];
     for await (const dayNote of this.list(query, options)) {
       dayNotes.push(dayNote);
@@ -57,13 +57,13 @@ export class DayNotesService extends Service<DayNote> {
     return dayNotes;
   }
 
-  listByPage(query: DayNotesQueryParams): AsyncGenerator<AxiosResponse<DayNote[]>>;
+  listByPage(query?: DayNotesQueryParams): AsyncGenerator<AxiosResponse<DayNote[]>>;
   listByPage<F extends keyof DayNote>(
     query: DayNotesQueryParams,
     options: { fields: F[] } & OptionsExtended<DayNote>,
   ): AsyncGenerator<AxiosResponse<Pick<DayNote, F>[]>>;
-  listByPage(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>): AsyncGenerator<AxiosResponse<DayNote[]>>;
-  listByPage(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
+  listByPage(query?: DayNotesQueryParams, options?: OptionsExtended<DayNote>): AsyncGenerator<AxiosResponse<DayNote[]>>;
+  listByPage(query?: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/day-notes.service.ts
+++ b/src/services/day-notes.service.ts
@@ -33,23 +33,23 @@ export class DayNotesService extends Service<DayNote> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query?: DayNotesQueryParams): AsyncGenerator<DayNote>;
+  list(query: DayNotesQueryParams): AsyncGenerator<DayNote>;
   list<F extends keyof DayNote>(
     query: DayNotesQueryParams,
     options: { fields: F[] } & OptionsExtended<DayNote>,
   ): AsyncGenerator<Pick<DayNote, F>>;
-  list(query?: DayNotesQueryParams, options?: OptionsExtended<DayNote>): AsyncGenerator<DayNote>;
-  async *list(query?: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
+  list(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>): AsyncGenerator<DayNote>;
+  async *list(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query?: DayNotesQueryParams): Promise<DayNote[]>;
+  listAll(query: DayNotesQueryParams): Promise<DayNote[]>;
   listAll<F extends keyof DayNote>(
     query: DayNotesQueryParams,
     options: { fields: F[] } & OptionsExtended<DayNote>,
   ): Promise<Pick<DayNote, F>[]>;
-  listAll(query?: DayNotesQueryParams, options?: OptionsExtended<DayNote>): Promise<DayNote[]>;
-  async listAll(query?: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
+  listAll(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>): Promise<DayNote[]>;
+  async listAll(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
     const dayNotes: DayNote[] = [];
     for await (const dayNote of this.list(query, options)) {
       dayNotes.push(dayNote);
@@ -57,13 +57,13 @@ export class DayNotesService extends Service<DayNote> {
     return dayNotes;
   }
 
-  listByPage(query?: DayNotesQueryParams): AsyncGenerator<AxiosResponse<DayNote[]>>;
+  listByPage(query: DayNotesQueryParams): AsyncGenerator<AxiosResponse<DayNote[]>>;
   listByPage<F extends keyof DayNote>(
     query: DayNotesQueryParams,
     options: { fields: F[] } & OptionsExtended<DayNote>,
   ): AsyncGenerator<AxiosResponse<Pick<DayNote, F>[]>>;
-  listByPage(query?: DayNotesQueryParams, options?: OptionsExtended<DayNote>): AsyncGenerator<AxiosResponse<DayNote[]>>;
-  listByPage(query?: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
+  listByPage(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>): AsyncGenerator<AxiosResponse<DayNote[]>>;
+  listByPage(query: DayNotesQueryParams, options?: OptionsExtended<DayNote>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/day-notes.service.ts
+++ b/src/services/day-notes.service.ts
@@ -89,11 +89,11 @@ export class DayNotesService extends Service<DayNote> {
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   delete(id: number, options: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .fetch<void>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/days-off.service.ts
+++ b/src/services/days-off.service.ts
@@ -43,7 +43,7 @@ export class DaysOffService extends Service<DaysOff> {
   listAll(query: DaysOffQueryParams): Promise<DaysOff[]>;
   listAll<F extends keyof DaysOff>(
     query: DaysOffQueryParams,
-    options: { fields: F[] } & OptionsExtended<DaysOff[]>,
+    options: { fields: F[] } & OptionsExtended<DaysOff>,
   ): Promise<Pick<DaysOff, F>[]>;
   listAll(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>): Promise<DaysOff[]>;
   async listAll(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>) {
@@ -57,7 +57,7 @@ export class DaysOffService extends Service<DaysOff> {
   listByPage(query: DaysOffQueryParams): AsyncGenerator<AxiosResponse<DaysOff[]>>;
   listByPage<F extends keyof DaysOff>(
     query: DaysOffQueryParams,
-    options: { fields: F[] } & OptionsExtended<DaysOff[]>,
+    options: { fields: F[] } & OptionsExtended<DaysOff>,
   ): AsyncGenerator<AxiosResponse<Pick<DaysOff, F>[]>>;
   listByPage(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>): AsyncGenerator<AxiosResponse<DaysOff[]>>;
   listByPage(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>) {

--- a/src/services/days-off.service.ts
+++ b/src/services/days-off.service.ts
@@ -28,7 +28,7 @@ export class DaysOffService extends Service<DaysOff> {
   }
 
   async *list(query: DaysOffQueryParams, options?: Options) {
-    for await (const res of super.iterator({ url: this.apiPath, params: query }, options)) {
+    for await (const res of super.iterator<DaysOff>({ url: this.apiPath, params: query }, options)) {
       yield res;
     }
   }

--- a/src/services/days-off.service.ts
+++ b/src/services/days-off.service.ts
@@ -65,11 +65,11 @@ export class DaysOffService extends Service<DaysOff> {
   }
 
   delete(dates: string[], users: number[]): Promise<number>;
-  delete(dates: string[], users: number[], options: { rawResponse: true } & Options): Promise<AxiosResponse<any, any>>;
+  delete(dates: string[], users: number[], options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   delete(dates: string[], users: number[], options: Options): Promise<number>;
   delete(dates: string[], users: number[], options?: Options) {
     return super
-      .fetch(
+      .fetch<void>(
         {
           url: this.apiPath,
           method: 'DELETE',

--- a/src/services/days-off.service.ts
+++ b/src/services/days-off.service.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { DaysOff } from '../interfaces/index.js';
-import { Service, Options } from './index.js';
+import { Service, Options, OptionsExtended } from './index.js';
 
 import { DaysOffQueryParams } from '../interfaces/query-params/days-off-query-params.interface.js';
 
@@ -16,25 +16,37 @@ export class DaysOffService extends Service<DaysOff> {
   create(dates: string[], users: number[], options: Options): Promise<number>;
   create(dates: string[], users: number[], options?: Options) {
     return super
-      .fetch({
-        url: this.apiPath,
-        data: {
-          dates,
-          users,
+      .fetch<DaysOff>(
+        {
+          url: this.apiPath,
+          data: {
+            dates,
+            users,
+          },
+          method: 'POST',
         },
-        method: 'POST',
-      })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+        options,
+      )
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 
-  async *list(query: DaysOffQueryParams, options?: Options) {
-    for await (const res of super.iterator<DaysOff>({ url: this.apiPath, params: query }, options)) {
-      yield res;
-    }
+  list(query: DaysOffQueryParams): AsyncGenerator<DaysOff>;
+  list<F extends keyof DaysOff>(
+    query: DaysOffQueryParams,
+    options: { fields: F[] } & OptionsExtended<DaysOff>,
+  ): AsyncGenerator<Pick<DaysOff, F>>;
+  list(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>): AsyncGenerator<DaysOff>;
+  async *list(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>) {
+    yield* super.iterator<DaysOff>({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: DaysOffQueryParams, options?: Options): Promise<DaysOff[]>;
-  async listAll(query: DaysOffQueryParams, options?: Options) {
+  listAll(query: DaysOffQueryParams): Promise<DaysOff[]>;
+  listAll<F extends keyof DaysOff>(
+    query: DaysOffQueryParams,
+    options: { fields: F[] } & OptionsExtended<DaysOff[]>,
+  ): Promise<Pick<DaysOff, F>[]>;
+  listAll(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>): Promise<DaysOff[]>;
+  async listAll(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>) {
     const daysOff = [] as DaysOff[];
     for await (const dayOff of this.list(query, options)) {
       daysOff.push(dayOff);
@@ -42,7 +54,13 @@ export class DaysOffService extends Service<DaysOff> {
     return daysOff;
   }
 
-  listByPage(query: DaysOffQueryParams, options?: Options) {
+  listByPage(query: DaysOffQueryParams): AsyncGenerator<AxiosResponse<DaysOff[]>>;
+  listByPage<F extends keyof DaysOff>(
+    query: DaysOffQueryParams,
+    options: { fields: F[] } & OptionsExtended<DaysOff[]>,
+  ): AsyncGenerator<AxiosResponse<Pick<DaysOff, F>[]>>;
+  listByPage(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>): AsyncGenerator<AxiosResponse<DaysOff[]>>;
+  listByPage(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 
@@ -51,14 +69,17 @@ export class DaysOffService extends Service<DaysOff> {
   delete(dates: string[], users: number[], options: Options): Promise<number>;
   delete(dates: string[], users: number[], options?: Options) {
     return super
-      .fetch({
-        url: this.apiPath,
-        method: 'DELETE',
-        data: {
-          dates,
-          users,
+      .fetch(
+        {
+          url: this.apiPath,
+          method: 'DELETE',
+          data: {
+            dates,
+            users,
+          },
         },
-      })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+        options,
+      )
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/days-off.service.ts
+++ b/src/services/days-off.service.ts
@@ -30,23 +30,23 @@ export class DaysOffService extends Service<DaysOff> {
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 
-  list(query: DaysOffQueryParams): AsyncGenerator<DaysOff>;
+  list(query?: DaysOffQueryParams): AsyncGenerator<DaysOff>;
   list<F extends keyof DaysOff>(
     query: DaysOffQueryParams,
     options: { fields: F[] } & OptionsExtended<DaysOff>,
   ): AsyncGenerator<Pick<DaysOff, F>>;
-  list(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>): AsyncGenerator<DaysOff>;
-  async *list(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>) {
+  list(query?: DaysOffQueryParams, options?: OptionsExtended<DaysOff>): AsyncGenerator<DaysOff>;
+  async *list(query?: DaysOffQueryParams, options?: OptionsExtended<DaysOff>) {
     yield* super.iterator<DaysOff>({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: DaysOffQueryParams): Promise<DaysOff[]>;
+  listAll(query?: DaysOffQueryParams): Promise<DaysOff[]>;
   listAll<F extends keyof DaysOff>(
     query: DaysOffQueryParams,
     options: { fields: F[] } & OptionsExtended<DaysOff>,
   ): Promise<Pick<DaysOff, F>[]>;
-  listAll(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>): Promise<DaysOff[]>;
-  async listAll(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>) {
+  listAll(query?: DaysOffQueryParams, options?: OptionsExtended<DaysOff>): Promise<DaysOff[]>;
+  async listAll(query?: DaysOffQueryParams, options?: OptionsExtended<DaysOff>) {
     const daysOff = [] as DaysOff[];
     for await (const dayOff of this.list(query, options)) {
       daysOff.push(dayOff);
@@ -54,13 +54,13 @@ export class DaysOffService extends Service<DaysOff> {
     return daysOff;
   }
 
-  listByPage(query: DaysOffQueryParams): AsyncGenerator<AxiosResponse<DaysOff[]>>;
+  listByPage(query?: DaysOffQueryParams): AsyncGenerator<AxiosResponse<DaysOff[]>>;
   listByPage<F extends keyof DaysOff>(
     query: DaysOffQueryParams,
     options: { fields: F[] } & OptionsExtended<DaysOff>,
   ): AsyncGenerator<AxiosResponse<Pick<DaysOff, F>[]>>;
-  listByPage(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>): AsyncGenerator<AxiosResponse<DaysOff[]>>;
-  listByPage(query: DaysOffQueryParams, options?: OptionsExtended<DaysOff>) {
+  listByPage(query?: DaysOffQueryParams, options?: OptionsExtended<DaysOff>): AsyncGenerator<AxiosResponse<DaysOff[]>>;
+  listByPage(query?: DaysOffQueryParams, options?: OptionsExtended<DaysOff>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/groups.service.ts
+++ b/src/services/groups.service.ts
@@ -87,11 +87,11 @@ export class GroupsService extends Service<Group> {
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   delete(id: number, options: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
+      .fetch<void>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/groups.service.ts
+++ b/src/services/groups.service.ts
@@ -48,7 +48,7 @@ export class GroupsService extends Service<Group> {
   listAll(query: GroupsQueryParams): Promise<Group[]>;
   listAll<F extends keyof Group>(
     query: GroupsQueryParams,
-    options: { fields: F[] } & OptionsExtended<Group[]>,
+    options: { fields: F[] } & OptionsExtended<Group>,
   ): Promise<Pick<Group, F>[]>;
   listAll(query: GroupsQueryParams, options?: OptionsExtended<Group>): Promise<Group[]>;
   async listAll(query: GroupsQueryParams, options?: OptionsExtended<Group>) {
@@ -62,7 +62,7 @@ export class GroupsService extends Service<Group> {
   listByPage(query: GroupsQueryParams): AsyncGenerator<AxiosResponse<Group[]>>;
   listByPage<F extends keyof Group>(
     query: GroupsQueryParams,
-    options: { fields: F[] } & OptionsExtended<Group[]>,
+    options: { fields: F[] } & OptionsExtended<Group>,
   ): AsyncGenerator<AxiosResponse<Pick<Group, F>[]>>;
   listByPage(query: GroupsQueryParams, options?: OptionsExtended<Group>): AsyncGenerator<AxiosResponse<Group[]>>;
   listByPage(query?: GroupsQueryParams, options?: OptionsExtended<Group>) {

--- a/src/services/groups.service.ts
+++ b/src/services/groups.service.ts
@@ -35,23 +35,23 @@ export class GroupsService extends Service<Group> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query: GroupsQueryParams): AsyncGenerator<Group>;
+  list(query?: GroupsQueryParams): AsyncGenerator<Group>;
   list<F extends keyof Group>(
     query: GroupsQueryParams,
     options: { fields: F[] } & OptionsExtended<Group>,
   ): AsyncGenerator<Pick<Group, F>>;
-  list(query: GroupsQueryParams, options?: OptionsExtended<Group>): AsyncGenerator<Group>;
+  list(query?: GroupsQueryParams, options?: OptionsExtended<Group>): AsyncGenerator<Group>;
   async *list(query?: GroupsQueryParams, options?: OptionsExtended<Group>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: GroupsQueryParams): Promise<Group[]>;
+  listAll(query?: GroupsQueryParams): Promise<Group[]>;
   listAll<F extends keyof Group>(
     query: GroupsQueryParams,
     options: { fields: F[] } & OptionsExtended<Group>,
   ): Promise<Pick<Group, F>[]>;
-  listAll(query: GroupsQueryParams, options?: OptionsExtended<Group>): Promise<Group[]>;
-  async listAll(query: GroupsQueryParams, options?: OptionsExtended<Group>) {
+  listAll(query?: GroupsQueryParams, options?: OptionsExtended<Group>): Promise<Group[]>;
+  async listAll(query?: GroupsQueryParams, options?: OptionsExtended<Group>) {
     const groups = [] as Group[];
     for await (const group of this.list(query, options)) {
       groups.push(group);
@@ -59,12 +59,12 @@ export class GroupsService extends Service<Group> {
     return groups;
   }
 
-  listByPage(query: GroupsQueryParams): AsyncGenerator<AxiosResponse<Group[]>>;
+  listByPage(query?: GroupsQueryParams): AsyncGenerator<AxiosResponse<Group[]>>;
   listByPage<F extends keyof Group>(
     query: GroupsQueryParams,
     options: { fields: F[] } & OptionsExtended<Group>,
   ): AsyncGenerator<AxiosResponse<Pick<Group, F>[]>>;
-  listByPage(query: GroupsQueryParams, options?: OptionsExtended<Group>): AsyncGenerator<AxiosResponse<Group[]>>;
+  listByPage(query?: GroupsQueryParams, options?: OptionsExtended<Group>): AsyncGenerator<AxiosResponse<Group[]>>;
   listByPage(query?: GroupsQueryParams, options?: OptionsExtended<Group>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }

--- a/src/services/leave-embargoes.service.ts
+++ b/src/services/leave-embargoes.service.ts
@@ -90,11 +90,11 @@ export class LeaveEmbargoesService extends Service<LeaveEmbargo> {
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   delete(id: number, options: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .fetch<void>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/leave-embargoes.service.ts
+++ b/src/services/leave-embargoes.service.ts
@@ -38,7 +38,13 @@ export class LeaveEmbargoesService extends Service<LeaveEmbargo> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  async *list(query: LeaveEmbargoesQueryParams, options?: Options) {
+  list(query: LeaveEmbargoesQueryParams): AsyncGenerator<LeaveEmbargo>;
+  list<F extends keyof LeaveEmbargo>(
+    query: LeaveEmbargoesQueryParams,
+    options: { fields: F[] } & OptionsExtended<LeaveEmbargo>,
+  ): AsyncGenerator<Pick<LeaveEmbargo, F>>;
+  list(query: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>): AsyncGenerator<LeaveEmbargo>;
+  async *list(query: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
@@ -48,7 +54,7 @@ export class LeaveEmbargoesService extends Service<LeaveEmbargo> {
     options: { fields: F[] } & OptionsExtended<LeaveEmbargo>,
   ): Promise<Pick<LeaveEmbargo, F>[]>;
   listAll(query: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>): Promise<LeaveEmbargo[]>;
-  async listAll(query: LeaveEmbargoesQueryParams, options?: Options) {
+  async listAll(query: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>) {
     const leave = [] as LeaveEmbargo[];
     for await (const leaveEmbargoRecord of this.list(query, options)) {
       leave.push(leaveEmbargoRecord);

--- a/src/services/leave-embargoes.service.ts
+++ b/src/services/leave-embargoes.service.ts
@@ -38,23 +38,23 @@ export class LeaveEmbargoesService extends Service<LeaveEmbargo> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query: LeaveEmbargoesQueryParams): AsyncGenerator<LeaveEmbargo>;
+  list(query?: LeaveEmbargoesQueryParams): AsyncGenerator<LeaveEmbargo>;
   list<F extends keyof LeaveEmbargo>(
     query: LeaveEmbargoesQueryParams,
     options: { fields: F[] } & OptionsExtended<LeaveEmbargo>,
   ): AsyncGenerator<Pick<LeaveEmbargo, F>>;
-  list(query: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>): AsyncGenerator<LeaveEmbargo>;
-  async *list(query: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>) {
+  list(query?: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>): AsyncGenerator<LeaveEmbargo>;
+  async *list(query?: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: LeaveEmbargoesQueryParams): Promise<LeaveEmbargo[]>;
+  listAll(query?: LeaveEmbargoesQueryParams): Promise<LeaveEmbargo[]>;
   listAll<F extends keyof LeaveEmbargo>(
     query: LeaveEmbargoesQueryParams,
     options: { fields: F[] } & OptionsExtended<LeaveEmbargo>,
   ): Promise<Pick<LeaveEmbargo, F>[]>;
-  listAll(query: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>): Promise<LeaveEmbargo[]>;
-  async listAll(query: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>) {
+  listAll(query?: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>): Promise<LeaveEmbargo[]>;
+  async listAll(query?: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>) {
     const leave = [] as LeaveEmbargo[];
     for await (const leaveEmbargoRecord of this.list(query, options)) {
       leave.push(leaveEmbargoRecord);
@@ -62,7 +62,7 @@ export class LeaveEmbargoesService extends Service<LeaveEmbargo> {
     return leave;
   }
 
-  listByPage(query: LeaveEmbargoesQueryParams): AsyncGenerator<AxiosResponse<LeaveEmbargo[]>>;
+  listByPage(query?: LeaveEmbargoesQueryParams): AsyncGenerator<AxiosResponse<LeaveEmbargo[]>>;
   listByPage<F extends keyof LeaveEmbargo>(
     query: LeaveEmbargoesQueryParams,
     options: { fields: F[] } & OptionsExtended<LeaveEmbargo>,
@@ -71,7 +71,7 @@ export class LeaveEmbargoesService extends Service<LeaveEmbargo> {
     query: LeaveEmbargoesQueryParams,
     options?: OptionsExtended<LeaveEmbargo>,
   ): AsyncGenerator<AxiosResponse<LeaveEmbargo[]>>;
-  listByPage(query: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>) {
+  listByPage(query?: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/leave-embargoes.service.ts
+++ b/src/services/leave-embargoes.service.ts
@@ -6,7 +6,7 @@ import { LeaveEmbargoesQueryParams } from '../rotacloud.js';
 
 type RequiredProps = 'start_date' | 'end_date' | 'users';
 
-export class LeaveEmbargoesService extends Service {
+export class LeaveEmbargoesService extends Service<LeaveEmbargo> {
   private apiPath = '/leave_embargoes';
 
   create(data: RequirementsOf<LeaveEmbargo, RequiredProps>): Promise<LeaveEmbargo>;

--- a/src/services/leave-embargoes.service.ts
+++ b/src/services/leave-embargoes.service.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { LeaveEmbargo } from '../interfaces/index.js';
-import { Service, Options, RequirementsOf } from './index.js';
+import { Service, Options, RequirementsOf, OptionsExtended } from './index.js';
 
 import { LeaveEmbargoesQueryParams } from '../rotacloud.js';
 
@@ -17,26 +17,37 @@ export class LeaveEmbargoesService extends Service<LeaveEmbargo> {
   create(data: RequirementsOf<LeaveEmbargo, RequiredProps>, options: Options): Promise<LeaveEmbargo>;
   create(data: RequirementsOf<LeaveEmbargo, RequiredProps>, options?: Options) {
     return super
-      .fetch<LeaveEmbargo>({ url: this.apiPath, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<LeaveEmbargo>({ url: this.apiPath, data, method: 'POST' }, options)
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   get(id: number): Promise<LeaveEmbargo>;
-  get(id: number, options: { rawResponse: true }): Promise<AxiosResponse<LeaveEmbargo, any>>;
-  get(id: number, options: Options): Promise<LeaveEmbargo>;
-  get(id: number, options?: Options) {
+  get<F extends keyof LeaveEmbargo>(
+    id: number,
+    options: { fields: F[]; rawResponse: true } & OptionsExtended<LeaveEmbargo>,
+  ): Promise<AxiosResponse<Pick<LeaveEmbargo, F>>>;
+  get<F extends keyof LeaveEmbargo>(
+    id: number,
+    options: { fields: F[] } & OptionsExtended<LeaveEmbargo>,
+  ): Promise<Pick<LeaveEmbargo, F>>;
+  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<LeaveEmbargo>>;
+  get(id: number, options?: OptionsExtended<LeaveEmbargo>): Promise<LeaveEmbargo>;
+  get(id: number, options?: OptionsExtended<LeaveEmbargo>) {
     return super
       .fetch<LeaveEmbargo>({ url: `${this.apiPath}/${id}` }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   async *list(query: LeaveEmbargoesQueryParams, options?: Options) {
-    for await (const res of super.iterator<LeaveEmbargo>({ url: this.apiPath, params: query }, options)) {
-      yield res;
-    }
+    yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: LeaveEmbargoesQueryParams, options?: Options): Promise<LeaveEmbargo[]>;
+  listAll(query: LeaveEmbargoesQueryParams): Promise<LeaveEmbargo[]>;
+  listAll<F extends keyof LeaveEmbargo>(
+    query: LeaveEmbargoesQueryParams,
+    options: { fields: F[] } & OptionsExtended<LeaveEmbargo[]>,
+  ): Promise<Pick<LeaveEmbargo, F>[]>;
+  listAll(query: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>): Promise<LeaveEmbargo[]>;
   async listAll(query: LeaveEmbargoesQueryParams, options?: Options) {
     const leave = [] as LeaveEmbargo[];
     for await (const leaveEmbargoRecord of this.list(query, options)) {
@@ -45,8 +56,17 @@ export class LeaveEmbargoesService extends Service<LeaveEmbargo> {
     return leave;
   }
 
-  listByPage(query: LeaveEmbargoesQueryParams, options?: Options) {
-    return super.iterator<LeaveEmbargo>({ url: this.apiPath, params: query }, options).byPage();
+  listByPage(query: LeaveEmbargoesQueryParams): AsyncGenerator<AxiosResponse<LeaveEmbargo[]>>;
+  listByPage<F extends keyof LeaveEmbargo>(
+    query: LeaveEmbargoesQueryParams,
+    options: { fields: F[] } & OptionsExtended<LeaveEmbargo[]>,
+  ): AsyncGenerator<AxiosResponse<Pick<LeaveEmbargo, F>[]>>;
+  listByPage(
+    query: LeaveEmbargoesQueryParams,
+    options?: OptionsExtended<LeaveEmbargo>,
+  ): AsyncGenerator<AxiosResponse<LeaveEmbargo[]>>;
+  listByPage(query: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>) {
+    return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 
   update(id: number, data: Partial<LeaveEmbargo>): Promise<LeaveEmbargo>;
@@ -58,20 +78,23 @@ export class LeaveEmbargoesService extends Service<LeaveEmbargo> {
   update(id: number, data: Partial<LeaveEmbargo>, options: Options): Promise<LeaveEmbargo>;
   update(id: number, data: Partial<LeaveEmbargo>, options?: Options) {
     return super
-      .fetch<LeaveEmbargo>({
-        url: `${this.apiPath}/${id}`,
-        data,
-        method: 'POST',
-      })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<LeaveEmbargo>(
+        {
+          url: `${this.apiPath}/${id}`,
+          data,
+          method: 'POST',
+        },
+        options,
+      )
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<any, any>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
   delete(id: number, options: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<LeaveEmbargo>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/leave-embargoes.service.ts
+++ b/src/services/leave-embargoes.service.ts
@@ -45,7 +45,7 @@ export class LeaveEmbargoesService extends Service<LeaveEmbargo> {
   listAll(query: LeaveEmbargoesQueryParams): Promise<LeaveEmbargo[]>;
   listAll<F extends keyof LeaveEmbargo>(
     query: LeaveEmbargoesQueryParams,
-    options: { fields: F[] } & OptionsExtended<LeaveEmbargo[]>,
+    options: { fields: F[] } & OptionsExtended<LeaveEmbargo>,
   ): Promise<Pick<LeaveEmbargo, F>[]>;
   listAll(query: LeaveEmbargoesQueryParams, options?: OptionsExtended<LeaveEmbargo>): Promise<LeaveEmbargo[]>;
   async listAll(query: LeaveEmbargoesQueryParams, options?: Options) {
@@ -59,7 +59,7 @@ export class LeaveEmbargoesService extends Service<LeaveEmbargo> {
   listByPage(query: LeaveEmbargoesQueryParams): AsyncGenerator<AxiosResponse<LeaveEmbargo[]>>;
   listByPage<F extends keyof LeaveEmbargo>(
     query: LeaveEmbargoesQueryParams,
-    options: { fields: F[] } & OptionsExtended<LeaveEmbargo[]>,
+    options: { fields: F[] } & OptionsExtended<LeaveEmbargo>,
   ): AsyncGenerator<AxiosResponse<Pick<LeaveEmbargo, F>[]>>;
   listByPage(
     query: LeaveEmbargoesQueryParams,

--- a/src/services/leave-request.service.ts
+++ b/src/services/leave-request.service.ts
@@ -58,7 +58,7 @@ export class LeaveRequestService extends Service<LeaveRequest> {
   listAll(query: LeaveRequestsQueryParams): Promise<LeaveRequest[]>;
   listAll<F extends keyof LeaveRequest>(
     query: LeaveRequestsQueryParams,
-    options: { fields: F[] } & OptionsExtended<LeaveRequest[]>,
+    options: { fields: F[] } & OptionsExtended<LeaveRequest>,
   ): Promise<Pick<LeaveRequest, F>[]>;
   listAll(query: LeaveRequestsQueryParams, options?: OptionsExtended<LeaveRequest>): Promise<LeaveRequest[]>;
   async listAll(query: LeaveRequestsQueryParams, options?: OptionsExtended<LeaveRequest>) {
@@ -72,7 +72,7 @@ export class LeaveRequestService extends Service<LeaveRequest> {
   listByPage(query: LeaveRequestsQueryParams): AsyncGenerator<AxiosResponse<LeaveRequest[]>>;
   listByPage<F extends keyof LeaveRequest>(
     query: LeaveRequestsQueryParams,
-    options: { fields: F[] } & OptionsExtended<LeaveRequest[]>,
+    options: { fields: F[] } & OptionsExtended<LeaveRequest>,
   ): AsyncGenerator<AxiosResponse<Pick<LeaveRequest, F>[]>>;
   listByPage(
     query: LeaveRequestsQueryParams,

--- a/src/services/leave-request.service.ts
+++ b/src/services/leave-request.service.ts
@@ -45,23 +45,23 @@ export class LeaveRequestService extends Service<LeaveRequest> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query: LeaveRequestsQueryParams): AsyncGenerator<LeaveRequest>;
+  list(query?: LeaveRequestsQueryParams): AsyncGenerator<LeaveRequest>;
   list<F extends keyof LeaveRequest>(
     query: LeaveRequestsQueryParams,
     options: { fields: F[] } & OptionsExtended<LeaveRequest>,
   ): AsyncGenerator<Pick<LeaveRequest, F>>;
-  list(query: LeaveRequestsQueryParams, options?: OptionsExtended<LeaveRequest>): AsyncGenerator<LeaveRequest>;
+  list(query?: LeaveRequestsQueryParams, options?: OptionsExtended<LeaveRequest>): AsyncGenerator<LeaveRequest>;
   async *list(query?: LeaveRequestsQueryParams, options?: OptionsExtended<LeaveRequest>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: LeaveRequestsQueryParams): Promise<LeaveRequest[]>;
+  listAll(query?: LeaveRequestsQueryParams): Promise<LeaveRequest[]>;
   listAll<F extends keyof LeaveRequest>(
     query: LeaveRequestsQueryParams,
     options: { fields: F[] } & OptionsExtended<LeaveRequest>,
   ): Promise<Pick<LeaveRequest, F>[]>;
-  listAll(query: LeaveRequestsQueryParams, options?: OptionsExtended<LeaveRequest>): Promise<LeaveRequest[]>;
-  async listAll(query: LeaveRequestsQueryParams, options?: OptionsExtended<LeaveRequest>) {
+  listAll(query?: LeaveRequestsQueryParams, options?: OptionsExtended<LeaveRequest>): Promise<LeaveRequest[]>;
+  async listAll(query?: LeaveRequestsQueryParams, options?: OptionsExtended<LeaveRequest>) {
     const leave = [] as LeaveRequest[];
     for await (const leaveRequestRecord of this.list(query, options)) {
       leave.push(leaveRequestRecord);
@@ -69,7 +69,7 @@ export class LeaveRequestService extends Service<LeaveRequest> {
     return leave;
   }
 
-  listByPage(query: LeaveRequestsQueryParams): AsyncGenerator<AxiosResponse<LeaveRequest[]>>;
+  listByPage(query?: LeaveRequestsQueryParams): AsyncGenerator<AxiosResponse<LeaveRequest[]>>;
   listByPage<F extends keyof LeaveRequest>(
     query: LeaveRequestsQueryParams,
     options: { fields: F[] } & OptionsExtended<LeaveRequest>,

--- a/src/services/leave-request.service.ts
+++ b/src/services/leave-request.service.ts
@@ -103,11 +103,11 @@ export class LeaveRequestService extends Service<LeaveRequest> {
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   delete(id: number, options: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .fetch<void>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/leave.service.ts
+++ b/src/services/leave.service.ts
@@ -48,7 +48,7 @@ export class LeaveService extends Service<Leave> {
   listAll(query: LeaveQueryParams): Promise<Leave[]>;
   listAll<F extends keyof Leave>(
     query: LeaveQueryParams,
-    options: { fields: F[] } & OptionsExtended<Leave[]>,
+    options: { fields: F[] } & OptionsExtended<Leave>,
   ): Promise<Pick<Leave, F>[]>;
   listAll(query: LeaveQueryParams, options?: OptionsExtended<Leave>): Promise<Leave[]>;
   async listAll(query: LeaveQueryParams, options?: OptionsExtended<Leave>) {
@@ -62,7 +62,7 @@ export class LeaveService extends Service<Leave> {
   listByPage(query: LeaveQueryParams): AsyncGenerator<AxiosResponse<Leave[]>>;
   listByPage<F extends keyof Leave>(
     query: LeaveQueryParams,
-    options: { fields: F[] } & OptionsExtended<Leave[]>,
+    options: { fields: F[] } & OptionsExtended<Leave>,
   ): AsyncGenerator<AxiosResponse<Pick<Leave, F>[]>>;
   listByPage(query: LeaveQueryParams, options?: OptionsExtended<Leave>): AsyncGenerator<AxiosResponse<Leave[]>>;
   listByPage(query: LeaveQueryParams, options?: OptionsExtended<Leave>) {

--- a/src/services/leave.service.ts
+++ b/src/services/leave.service.ts
@@ -90,11 +90,11 @@ export class LeaveService extends Service<Leave> {
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   delete(id: number, options: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
+      .fetch<void>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/leave.service.ts
+++ b/src/services/leave.service.ts
@@ -35,23 +35,23 @@ export class LeaveService extends Service<Leave> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query: LeaveQueryParams): AsyncGenerator<Leave>;
+  list(query?: LeaveQueryParams): AsyncGenerator<Leave>;
   list<F extends keyof Leave>(
     query: LeaveQueryParams,
     options: { fields: F[] } & OptionsExtended<Leave>,
   ): AsyncGenerator<Pick<Leave, F>>;
-  list(query: LeaveQueryParams, options?: OptionsExtended<Leave>): AsyncGenerator<Leave>;
-  async *list(query: LeaveQueryParams, options?: OptionsExtended<Leave>) {
+  list(query?: LeaveQueryParams, options?: OptionsExtended<Leave>): AsyncGenerator<Leave>;
+  async *list(query?: LeaveQueryParams, options?: OptionsExtended<Leave>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: LeaveQueryParams): Promise<Leave[]>;
+  listAll(query?: LeaveQueryParams): Promise<Leave[]>;
   listAll<F extends keyof Leave>(
     query: LeaveQueryParams,
     options: { fields: F[] } & OptionsExtended<Leave>,
   ): Promise<Pick<Leave, F>[]>;
-  listAll(query: LeaveQueryParams, options?: OptionsExtended<Leave>): Promise<Leave[]>;
-  async listAll(query: LeaveQueryParams, options?: OptionsExtended<Leave>) {
+  listAll(query?: LeaveQueryParams, options?: OptionsExtended<Leave>): Promise<Leave[]>;
+  async listAll(query?: LeaveQueryParams, options?: OptionsExtended<Leave>) {
     const leave = [] as Leave[];
     for await (const leaveRecord of this.list(query, options)) {
       leave.push(leaveRecord);
@@ -59,13 +59,13 @@ export class LeaveService extends Service<Leave> {
     return leave;
   }
 
-  listByPage(query: LeaveQueryParams): AsyncGenerator<AxiosResponse<Leave[]>>;
+  listByPage(query?: LeaveQueryParams): AsyncGenerator<AxiosResponse<Leave[]>>;
   listByPage<F extends keyof Leave>(
     query: LeaveQueryParams,
     options: { fields: F[] } & OptionsExtended<Leave>,
   ): AsyncGenerator<AxiosResponse<Pick<Leave, F>[]>>;
-  listByPage(query: LeaveQueryParams, options?: OptionsExtended<Leave>): AsyncGenerator<AxiosResponse<Leave[]>>;
-  listByPage(query: LeaveQueryParams, options?: OptionsExtended<Leave>) {
+  listByPage(query?: LeaveQueryParams, options?: OptionsExtended<Leave>): AsyncGenerator<AxiosResponse<Leave[]>>;
+  listByPage(query?: LeaveQueryParams, options?: OptionsExtended<Leave>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/locations.service.ts
+++ b/src/services/locations.service.ts
@@ -1,12 +1,12 @@
 import { AxiosResponse } from 'axios';
 import { Location } from '../interfaces/index.js';
-import { Service, Options, RequirementsOf } from './index.js';
+import { Service, Options, RequirementsOf, OptionsExtended } from './index.js';
 
 import { LocationsQueryParams } from '../interfaces/query-params/locations-query-params.interface.js';
 
 type RequiredProps = 'name';
 
-export class LocationsService extends Service {
+export class LocationsService extends Service<Location> {
   private apiPath = '/locations';
 
   create(data: RequirementsOf<Location, RequiredProps>): Promise<Location>;
@@ -17,27 +17,44 @@ export class LocationsService extends Service {
   create(data: RequirementsOf<Location, RequiredProps>, options: Options): Promise<Location>;
   create(data: RequirementsOf<Location, RequiredProps>, options?: Options) {
     return super
-      .fetch<Location>({ url: `${this.apiPath}`, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<Location>({ url: `${this.apiPath}`, data, method: 'POST' }, options)
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   get(id: number): Promise<Location>;
-  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<Location, any>>;
-  get(id: number, options: Options): Promise<Location>;
-  get(id: number, options?: Options) {
+  get<F extends keyof Location>(
+    id: number,
+    options: { fields: F[]; rawResponse: true } & OptionsExtended<Location>,
+  ): Promise<AxiosResponse<Pick<Location, F>>>;
+  get<F extends keyof Location>(
+    id: number,
+    options: { fields: F[] } & OptionsExtended<Location>,
+  ): Promise<Pick<Location, F>>;
+  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<Location>>;
+  get(id: number, options?: OptionsExtended<Location>): Promise<Location>;
+  get(id: number, options?: OptionsExtended<Location>) {
     return super
       .fetch<Location>({ url: `${this.apiPath}/${id}` }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  async *list(query?: LocationsQueryParams, options?: Options) {
-    for await (const res of super.iterator<Location>({ url: this.apiPath, params: query }, options)) {
-      yield res;
-    }
+  list(query: LocationsQueryParams): AsyncGenerator<Location>;
+  list<F extends keyof Location>(
+    query: LocationsQueryParams,
+    options: { fields: F[] } & OptionsExtended<Location>,
+  ): AsyncGenerator<Pick<Location, F>>;
+  list(query: LocationsQueryParams, options?: OptionsExtended<Location>): AsyncGenerator<Location>;
+  async *list(query?: LocationsQueryParams, options?: OptionsExtended<Location>) {
+    yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query?: LocationsQueryParams, options?: Options): Promise<Location[]>;
-  async listAll(query: LocationsQueryParams, options?: Options) {
+  listAll(query: LocationsQueryParams): Promise<Location[]>;
+  listAll<F extends keyof Location>(
+    query: LocationsQueryParams,
+    options: { fields: F[] } & OptionsExtended<Location[]>,
+  ): Promise<Pick<Location, F>[]>;
+  listAll(query: LocationsQueryParams, options?: OptionsExtended<Location>): Promise<Location[]>;
+  async listAll(query: LocationsQueryParams, options?: OptionsExtended<Location>) {
     const locations = [] as Location[];
     for await (const location of this.list(query, options)) {
       locations.push(location);
@@ -45,8 +62,17 @@ export class LocationsService extends Service {
     return locations;
   }
 
-  listByPage(query?: LocationsQueryParams, options?: Options) {
-    return super.iterator<Location>({ url: this.apiPath, params: query }, options).byPage();
+  listByPage(query: LocationsQueryParams): AsyncGenerator<AxiosResponse<Location[]>>;
+  listByPage<F extends keyof Location>(
+    query: LocationsQueryParams,
+    options: { fields: F[] } & OptionsExtended<Location[]>,
+  ): AsyncGenerator<AxiosResponse<Pick<Location, F>[]>>;
+  listByPage(
+    query: LocationsQueryParams,
+    options?: OptionsExtended<Location>,
+  ): AsyncGenerator<AxiosResponse<Location[]>>;
+  listByPage(query?: LocationsQueryParams, options?: OptionsExtended<Location>) {
+    return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 
   update(id: number, data: Partial<Location>): Promise<Location>;
@@ -58,20 +84,23 @@ export class LocationsService extends Service {
   update(id: number, data: Partial<Location>, options: Options): Promise<Location>;
   update(id: number, data: Partial<Location>, options?: Options) {
     return super
-      .fetch<Location>({
-        url: `${this.apiPath}/${id}`,
-        data,
-        method: 'POST',
-      })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<Location>(
+        {
+          url: `${this.apiPath}/${id}`,
+          data,
+          method: 'POST',
+        },
+        options,
+      )
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<any, any>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
   delete(id: number, options: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<Location>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/locations.service.ts
+++ b/src/services/locations.service.ts
@@ -38,23 +38,23 @@ export class LocationsService extends Service<Location> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query: LocationsQueryParams): AsyncGenerator<Location>;
+  list(query?: LocationsQueryParams): AsyncGenerator<Location>;
   list<F extends keyof Location>(
     query: LocationsQueryParams,
     options: { fields: F[] } & OptionsExtended<Location>,
   ): AsyncGenerator<Pick<Location, F>>;
-  list(query: LocationsQueryParams, options?: OptionsExtended<Location>): AsyncGenerator<Location>;
+  list(query?: LocationsQueryParams, options?: OptionsExtended<Location>): AsyncGenerator<Location>;
   async *list(query?: LocationsQueryParams, options?: OptionsExtended<Location>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: LocationsQueryParams): Promise<Location[]>;
+  listAll(query?: LocationsQueryParams): Promise<Location[]>;
   listAll<F extends keyof Location>(
     query: LocationsQueryParams,
     options: { fields: F[] } & OptionsExtended<Location>,
   ): Promise<Pick<Location, F>[]>;
-  listAll(query: LocationsQueryParams, options?: OptionsExtended<Location>): Promise<Location[]>;
-  async listAll(query: LocationsQueryParams, options?: OptionsExtended<Location>) {
+  listAll(query?: LocationsQueryParams, options?: OptionsExtended<Location>): Promise<Location[]>;
+  async listAll(query?: LocationsQueryParams, options?: OptionsExtended<Location>) {
     const locations = [] as Location[];
     for await (const location of this.list(query, options)) {
       locations.push(location);
@@ -62,7 +62,7 @@ export class LocationsService extends Service<Location> {
     return locations;
   }
 
-  listByPage(query: LocationsQueryParams): AsyncGenerator<AxiosResponse<Location[]>>;
+  listByPage(query?: LocationsQueryParams): AsyncGenerator<AxiosResponse<Location[]>>;
   listByPage<F extends keyof Location>(
     query: LocationsQueryParams,
     options: { fields: F[] } & OptionsExtended<Location>,

--- a/src/services/locations.service.ts
+++ b/src/services/locations.service.ts
@@ -96,11 +96,11 @@ export class LocationsService extends Service<Location> {
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   delete(id: number, options: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .fetch<void>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/locations.service.ts
+++ b/src/services/locations.service.ts
@@ -51,7 +51,7 @@ export class LocationsService extends Service<Location> {
   listAll(query: LocationsQueryParams): Promise<Location[]>;
   listAll<F extends keyof Location>(
     query: LocationsQueryParams,
-    options: { fields: F[] } & OptionsExtended<Location[]>,
+    options: { fields: F[] } & OptionsExtended<Location>,
   ): Promise<Pick<Location, F>[]>;
   listAll(query: LocationsQueryParams, options?: OptionsExtended<Location>): Promise<Location[]>;
   async listAll(query: LocationsQueryParams, options?: OptionsExtended<Location>) {
@@ -65,7 +65,7 @@ export class LocationsService extends Service<Location> {
   listByPage(query: LocationsQueryParams): AsyncGenerator<AxiosResponse<Location[]>>;
   listByPage<F extends keyof Location>(
     query: LocationsQueryParams,
-    options: { fields: F[] } & OptionsExtended<Location[]>,
+    options: { fields: F[] } & OptionsExtended<Location>,
   ): AsyncGenerator<AxiosResponse<Pick<Location, F>[]>>;
   listByPage(
     query: LocationsQueryParams,

--- a/src/services/pins.service.ts
+++ b/src/services/pins.service.ts
@@ -1,16 +1,21 @@
 import { AxiosResponse } from 'axios';
 import { Pin } from '../interfaces/index.js';
-import { Service, Options } from './index.js';
+import { Service, Options, OptionsExtended } from './index.js';
 
-export class PinsService extends Service {
+export class PinsService extends Service<Pin> {
   private apiPath = '/pins';
 
   get(id: string): Promise<Pin>;
-  get(id: string, options?: { rawResponse: true } & Options): Promise<AxiosResponse<Pin, any>>;
-  get(id: string, options?: Options): Promise<Pin>;
-  get(id: string, options?: Options) {
+  get<F extends keyof Pin>(
+    id: string,
+    options: { fields: F[]; rawResponse: true } & OptionsExtended<Pin>,
+  ): Promise<AxiosResponse<Pick<Pin, F>>>;
+  get<F extends keyof Pin>(id: string, options: { fields: F[] } & OptionsExtended<Pin>): Promise<Pick<Pin, F>>;
+  get(id: string, options: { rawResponse: true } & Options): Promise<AxiosResponse<Pin>>;
+  get(id: string, options?: OptionsExtended<Pin>): Promise<Pin>;
+  get(id: string, options?: OptionsExtended<Pin>) {
     return super
       .fetch<Pin>({ url: `${this.apiPath}/${id}` }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 }

--- a/src/services/roles.service.ts
+++ b/src/services/roles.service.ts
@@ -86,11 +86,11 @@ export class RolesService extends Service<Role> {
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   delete(id: number, options: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .fetch<void>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/roles.service.ts
+++ b/src/services/roles.service.ts
@@ -1,12 +1,12 @@
 import { AxiosResponse } from 'axios';
 import { Role } from '../interfaces/index.js';
-import { Service, Options, RequirementsOf } from './index.js';
+import { Service, Options, RequirementsOf, OptionsExtended } from './index.js';
 
 import { RolesQueryParams } from '../interfaces/query-params/roles-query-params.interface.js';
 
 type RequiredProps = 'name';
 
-export class RolesService extends Service {
+export class RolesService extends Service<Role> {
   private apiPath = '/roles';
 
   create(data: RequirementsOf<Role, RequiredProps>): Promise<Role>;
@@ -17,26 +17,40 @@ export class RolesService extends Service {
   create(data: RequirementsOf<Role, RequiredProps>, options: Options): Promise<Role>;
   create(data: RequirementsOf<Role, RequiredProps>, options?: Options) {
     return super
-      .fetch<Role>({ url: this.apiPath, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<Role>({ url: this.apiPath, data, method: 'POST' }, options)
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   get(id: number): Promise<Role>;
-  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<Role, any>>;
-  get(id: number, options: Options): Promise<Role>;
-  get(id: number, options?: Options) {
+  get<F extends keyof Role>(
+    id: number,
+    options: { fields: F[]; rawResponse: true } & OptionsExtended<Role>,
+  ): Promise<AxiosResponse<Pick<Role, F>>>;
+  get<F extends keyof Role>(id: number, options: { fields: F[] } & OptionsExtended<Role>): Promise<Pick<Role, F>>;
+  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<Role>>;
+  get(id: number, options?: OptionsExtended<Role>): Promise<Role>;
+  get(id: number, options?: OptionsExtended<Role>) {
     return super
       .fetch<Role>({ url: `${this.apiPath}/${id}` }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  async *list(query?: RolesQueryParams, options?: Options) {
-    for await (const res of super.iterator<Role>({ url: this.apiPath, params: query }, options)) {
-      yield res;
-    }
+  list(query: RolesQueryParams): AsyncGenerator<Role>;
+  list<F extends keyof Role>(
+    query: RolesQueryParams,
+    options: { fields: F[] } & OptionsExtended<Role>,
+  ): AsyncGenerator<Pick<Role, F>>;
+  list(query: RolesQueryParams, options?: OptionsExtended<Role>): AsyncGenerator<Role>;
+  async *list(query?: RolesQueryParams, options?: OptionsExtended<Role>) {
+    yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query?: RolesQueryParams, options?: Options): Promise<Role[]>;
+  listAll(query: RolesQueryParams): Promise<Role[]>;
+  listAll<F extends keyof Role>(
+    query: RolesQueryParams,
+    options: { fields: F[] } & OptionsExtended<Role[]>,
+  ): Promise<Pick<Role, F>[]>;
+  listAll(query: RolesQueryParams, options?: OptionsExtended<Role>): Promise<Role[]>;
   async listAll(query: RolesQueryParams, options?: Options) {
     const roles = [] as Role[];
     for await (const role of this.list(query, options)) {
@@ -45,28 +59,38 @@ export class RolesService extends Service {
     return roles;
   }
 
+  listByPage(query: RolesQueryParams): AsyncGenerator<AxiosResponse<Role[]>>;
+  listByPage<F extends keyof Role>(
+    query: RolesQueryParams,
+    options: { fields: F[] } & OptionsExtended<Role[]>,
+  ): AsyncGenerator<AxiosResponse<Pick<Role, F>[]>>;
+  listByPage(query: RolesQueryParams, options?: OptionsExtended<Role>): AsyncGenerator<AxiosResponse<Role[]>>;
   listByPage(query?: RolesQueryParams, options?: Options) {
-    return super.iterator<Role>({ url: this.apiPath, params: query }, options).byPage();
+    return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
+
   update(id: number, data: Partial<Role>): Promise<Role>;
   update(id: number, data: Partial<Role>, options: { rawResponse: true } & Options): Promise<AxiosResponse<Role, any>>;
   update(id: number, data: Partial<Role>, options: Options): Promise<Role>;
   update(id: number, data: Partial<Role>, options?: Options) {
     return super
-      .fetch<Role>({
-        url: `${this.apiPath}/${id}`,
-        data,
-        method: 'POST',
-      })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<Role>(
+        {
+          url: `${this.apiPath}/${id}`,
+          data,
+          method: 'POST',
+        },
+        options,
+      )
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<any, any>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
   delete(id: number, options: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<Role>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/roles.service.ts
+++ b/src/services/roles.service.ts
@@ -51,7 +51,7 @@ export class RolesService extends Service<Role> {
     options: { fields: F[] } & OptionsExtended<Role>,
   ): Promise<Pick<Role, F>[]>;
   listAll(query: RolesQueryParams, options?: OptionsExtended<Role>): Promise<Role[]>;
-  async listAll(query: RolesQueryParams, options?: Options) {
+  async listAll(query: RolesQueryParams, options?: OptionsExtended<Role>) {
     const roles = [] as Role[];
     for await (const role of this.list(query, options)) {
       roles.push(role);
@@ -65,7 +65,7 @@ export class RolesService extends Service<Role> {
     options: { fields: F[] } & OptionsExtended<Role>,
   ): AsyncGenerator<AxiosResponse<Pick<Role, F>[]>>;
   listByPage(query: RolesQueryParams, options?: OptionsExtended<Role>): AsyncGenerator<AxiosResponse<Role[]>>;
-  listByPage(query?: RolesQueryParams, options?: Options) {
+  listByPage(query?: RolesQueryParams, options?: OptionsExtended<Role>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/roles.service.ts
+++ b/src/services/roles.service.ts
@@ -35,23 +35,23 @@ export class RolesService extends Service<Role> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query: RolesQueryParams): AsyncGenerator<Role>;
+  list(query?: RolesQueryParams): AsyncGenerator<Role>;
   list<F extends keyof Role>(
     query: RolesQueryParams,
     options: { fields: F[] } & OptionsExtended<Role>,
   ): AsyncGenerator<Pick<Role, F>>;
-  list(query: RolesQueryParams, options?: OptionsExtended<Role>): AsyncGenerator<Role>;
+  list(query?: RolesQueryParams, options?: OptionsExtended<Role>): AsyncGenerator<Role>;
   async *list(query?: RolesQueryParams, options?: OptionsExtended<Role>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: RolesQueryParams): Promise<Role[]>;
+  listAll(query?: RolesQueryParams): Promise<Role[]>;
   listAll<F extends keyof Role>(
     query: RolesQueryParams,
     options: { fields: F[] } & OptionsExtended<Role>,
   ): Promise<Pick<Role, F>[]>;
-  listAll(query: RolesQueryParams, options?: OptionsExtended<Role>): Promise<Role[]>;
-  async listAll(query: RolesQueryParams, options?: OptionsExtended<Role>) {
+  listAll(query?: RolesQueryParams, options?: OptionsExtended<Role>): Promise<Role[]>;
+  async listAll(query?: RolesQueryParams, options?: OptionsExtended<Role>) {
     const roles = [] as Role[];
     for await (const role of this.list(query, options)) {
       roles.push(role);
@@ -59,12 +59,12 @@ export class RolesService extends Service<Role> {
     return roles;
   }
 
-  listByPage(query: RolesQueryParams): AsyncGenerator<AxiosResponse<Role[]>>;
+  listByPage(query?: RolesQueryParams): AsyncGenerator<AxiosResponse<Role[]>>;
   listByPage<F extends keyof Role>(
     query: RolesQueryParams,
     options: { fields: F[] } & OptionsExtended<Role>,
   ): AsyncGenerator<AxiosResponse<Pick<Role, F>[]>>;
-  listByPage(query: RolesQueryParams, options?: OptionsExtended<Role>): AsyncGenerator<AxiosResponse<Role[]>>;
+  listByPage(query?: RolesQueryParams, options?: OptionsExtended<Role>): AsyncGenerator<AxiosResponse<Role[]>>;
   listByPage(query?: RolesQueryParams, options?: OptionsExtended<Role>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }

--- a/src/services/roles.service.ts
+++ b/src/services/roles.service.ts
@@ -48,7 +48,7 @@ export class RolesService extends Service<Role> {
   listAll(query: RolesQueryParams): Promise<Role[]>;
   listAll<F extends keyof Role>(
     query: RolesQueryParams,
-    options: { fields: F[] } & OptionsExtended<Role[]>,
+    options: { fields: F[] } & OptionsExtended<Role>,
   ): Promise<Pick<Role, F>[]>;
   listAll(query: RolesQueryParams, options?: OptionsExtended<Role>): Promise<Role[]>;
   async listAll(query: RolesQueryParams, options?: Options) {
@@ -62,7 +62,7 @@ export class RolesService extends Service<Role> {
   listByPage(query: RolesQueryParams): AsyncGenerator<AxiosResponse<Role[]>>;
   listByPage<F extends keyof Role>(
     query: RolesQueryParams,
-    options: { fields: F[] } & OptionsExtended<Role[]>,
+    options: { fields: F[] } & OptionsExtended<Role>,
   ): AsyncGenerator<AxiosResponse<Pick<Role, F>[]>>;
   listByPage(query: RolesQueryParams, options?: OptionsExtended<Role>): AsyncGenerator<AxiosResponse<Role[]>>;
   listByPage(query?: RolesQueryParams, options?: Options) {

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -56,58 +56,6 @@ const DEFAULT_RETRY_STRATEGY_OPTIONS: Record<RetryStrategy, RetryOptions> = {
 type ParameterPrimitive = string | boolean | number | null | symbol;
 type ParameterValue = ParameterPrimitive | ParameterPrimitive[] | undefined;
 
-// declare function get<T>(id: number): Promise<T>;
-// /** @deprecated expand is not supported by every endpoint and will be removed in a future release */
-// declare function get<T>(
-//   id: number,
-//   options: {
-//     expand: string[];
-//     fields: string[];
-//     rawResponse: true;
-//   } & OptionsExtended<T>,
-// ): Promise<AxiosResponse<Partial<T>>>;
-// /** @deprecated expand is not supported by every endpoint and will be removed in a future release */
-// declare function get<T>(
-//   id: number,
-//   options: {
-//     expand: string[];
-//     fields: string[];
-//   } & OptionsExtended<T>,
-// ): Promise<Partial<T>>;
-// /** @deprecated expand is not supported by every endpoint and will be removed in a future release */
-// declare function get<T>(
-//   id: number,
-//   options: {
-//     expand: string[];
-//     rawResponse: true;
-//   } & OptionsExtended<T>,
-// ): Promise<AxiosResponse<T>>;
-// /** @deprecated expand is not supported by every endpoint and will be removed in a future release */
-// declare function get<T>(
-//   id: number,
-//   options: {
-//     expand: string[];
-//   } & OptionsExtended<T>,
-// ): Promise<T>;
-// declare function get<T, F extends keyof T>(
-//   id: number,
-//   options: { fields: F[]; rawResponse: true } & OptionsExtended<T>,
-// ): Promise<AxiosResponse<Pick<T, F>>>;
-// declare function get<T, F extends keyof T>(
-//   id: number,
-//   options: { fields: F[] } & OptionsExtended<T>,
-// ): Promise<Pick<T, F>>;
-// declare function get<T>(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<T>>;
-// declare function get<T>(id: number, options?: OptionsExtended<T>): Promise<T>;
-//
-// export function getFetch<T, S extends Service<T>>(baseService: S, apiPath: string): typeof get<T> {
-//   return function get(id: number, options?: OptionsExtended<T>) {
-//     return baseService
-//       .fetch<T>({ url: `${apiPath}/${id}` }, options)
-//       .then((res) => (options?.rawResponse ? res : res.data));
-//   };
-// }
-
 export abstract class Service<ApiResponse = any> {
   protected client: AxiosInstance = this.initialiseAxios();
 

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -30,8 +30,7 @@ export type RetryOptions =
 export interface Options<T = unknown> {
   rawResponse?: boolean;
   expand?: string[];
-  fields?: (keyof T)[];
-  // fields?: (keyof T | `${keyof T}.${string}`)[];
+  fields?: (keyof T | `${string & keyof T}.${string}`)[];
   limit?: number;
   offset?: number;
   dryRun?: boolean;

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -27,27 +27,15 @@ export type RetryOptions =
       maxRetries: number;
     };
 
-export type Options<T = unknown> =
-  | {
-      rawResponse?: boolean;
-      expand?: string[];
-      fields?: (keyof T)[];
-      limit?: number;
-      offset?: number;
-      dryRun?: boolean;
-    }
-  | {
-      rawResponse?: boolean;
-      expand: string[];
-      fields: (keyof T | `${string & keyof T}.${string}`)[];
-      limit?: number;
-      offset?: number;
-      dryRun?: boolean;
-    };
+export interface Options {
+  rawResponse?: boolean;
+  limit?: number;
+  offset?: number;
+  dryRun?: boolean;
+}
 
-export const testOpts: Options<{ prop1: string }> = {
-  expand: [],
-  fields: ['prop1', 'prop1.val'],
+export type OptionsExtended<T = unknown> = Options & {
+  fields?: (keyof T)[];
 };
 
 const DEFAULT_RETRIES = 3;
@@ -67,6 +55,58 @@ const DEFAULT_RETRY_STRATEGY_OPTIONS: Record<RetryStrategy, RetryOptions> = {
 
 type ParameterPrimitive = string | boolean | number | null | symbol;
 type ParameterValue = ParameterPrimitive | ParameterPrimitive[] | undefined;
+
+// declare function get<T>(id: number): Promise<T>;
+// /** @deprecated expand is not supported by every endpoint and will be removed in a future release */
+// declare function get<T>(
+//   id: number,
+//   options: {
+//     expand: string[];
+//     fields: string[];
+//     rawResponse: true;
+//   } & OptionsExtended<T>,
+// ): Promise<AxiosResponse<Partial<T>>>;
+// /** @deprecated expand is not supported by every endpoint and will be removed in a future release */
+// declare function get<T>(
+//   id: number,
+//   options: {
+//     expand: string[];
+//     fields: string[];
+//   } & OptionsExtended<T>,
+// ): Promise<Partial<T>>;
+// /** @deprecated expand is not supported by every endpoint and will be removed in a future release */
+// declare function get<T>(
+//   id: number,
+//   options: {
+//     expand: string[];
+//     rawResponse: true;
+//   } & OptionsExtended<T>,
+// ): Promise<AxiosResponse<T>>;
+// /** @deprecated expand is not supported by every endpoint and will be removed in a future release */
+// declare function get<T>(
+//   id: number,
+//   options: {
+//     expand: string[];
+//   } & OptionsExtended<T>,
+// ): Promise<T>;
+// declare function get<T, F extends keyof T>(
+//   id: number,
+//   options: { fields: F[]; rawResponse: true } & OptionsExtended<T>,
+// ): Promise<AxiosResponse<Pick<T, F>>>;
+// declare function get<T, F extends keyof T>(
+//   id: number,
+//   options: { fields: F[] } & OptionsExtended<T>,
+// ): Promise<Pick<T, F>>;
+// declare function get<T>(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<T>>;
+// declare function get<T>(id: number, options?: OptionsExtended<T>): Promise<T>;
+//
+// export function getFetch<T, S extends Service<T>>(baseService: S, apiPath: string): typeof get<T> {
+//   return function get(id: number, options?: OptionsExtended<T>) {
+//     return baseService
+//       .fetch<T>({ url: `${apiPath}/${id}` }, options)
+//       .then((res) => (options?.rawResponse ? res : res.data));
+//   };
+// }
 
 export abstract class Service<ApiResponse = any> {
   protected client: AxiosInstance = this.initialiseAxios();
@@ -101,9 +141,11 @@ export abstract class Service<ApiResponse = any> {
     return endpoint === '/leave_requests';
   }
 
-  private buildQueryParams<T = ApiResponse>(options?: Options<T>, extraParams?: Record<string, ParameterValue>) {
+  private buildQueryParams<T = ApiResponse>(
+    options?: OptionsExtended<T>,
+    extraParams?: Record<string, ParameterValue>,
+  ) {
     const queryParams: Record<string, ParameterValue> = {
-      expand: options?.expand,
       fields: options?.fields,
       limit: options?.limit,
       offset: options?.offset,
@@ -126,26 +168,18 @@ export abstract class Service<ApiResponse = any> {
   fetch<T = ApiResponse>(reqConfig: AxiosRequestConfig): Promise<AxiosResponse<T>>;
   fetch<T = ApiResponse>(
     reqConfig: AxiosRequestConfig,
-    options: { expand: string[] } & Options<T>,
-  ): Promise<AxiosResponse<T>>;
-  fetch<T = ApiResponse>(
-    reqConfig: AxiosRequestConfig,
-    options: { expand: undefined; fields: Required<Options<T>>['fields'] } & Options<T>,
+    options: { fields: Required<OptionsExtended<T>>['fields'] } & OptionsExtended<T>,
   ): Promise<AxiosResponse<Pick<T, (typeof options)['fields'][number]>>>;
   fetch<T extends unknown[] = ApiResponse[], E = T[number]>(
     reqConfig: AxiosRequestConfig,
-    options: { expand: string[] } & Options<E>,
-  ): Promise<AxiosResponse<E[]>>;
-  fetch<T extends unknown[] = ApiResponse[], E = T[number]>(
-    reqConfig: AxiosRequestConfig,
-    options: { expand: undefined; fields: Required<Options<E>>['fields'] } & Options<E>,
+    options: { fields: Required<OptionsExtended<E>>['fields'] } & OptionsExtended<E>,
   ): Promise<AxiosResponse<Pick<E, (typeof options)['fields'][number]>[]>>;
-  fetch<T extends unknown[] = ApiResponse[], E = T[number]>(
+  fetch<T extends unknown[] = ApiResponse[]>(
     reqConfig: AxiosRequestConfig,
-    options?: Options<E>,
-  ): Promise<AxiosResponse<E[]>>;
-  fetch<T = ApiResponse>(reqConfig: AxiosRequestConfig, options?: Options<T>): Promise<AxiosResponse<T | Partial<T>>>;
-  fetch<T = ApiResponse>(reqConfig: AxiosRequestConfig, options?: Options<T>) {
+    options?: Options,
+  ): Promise<AxiosResponse<T>>;
+  fetch<T = ApiResponse>(reqConfig: AxiosRequestConfig, options?: Options): Promise<AxiosResponse<T | Partial<T>>>;
+  fetch<T = ApiResponse>(reqConfig: AxiosRequestConfig, options?: Options) {
     const headers: Record<string, string> = {
       Authorization: RotaCloud.config.apiKey
         ? `Bearer ${RotaCloud.config.apiKey}`
@@ -197,22 +231,17 @@ export abstract class Service<ApiResponse = any> {
   }
 
   /** Iterates through every page for a potentially paginated request */
-  private fetchPages<T = ApiResponse>(reqConfig: AxiosRequestConfig<T[]>): AsyncGenerator<AxiosResponse<T[]>>;
   private fetchPages<T = ApiResponse>(
     reqConfig: AxiosRequestConfig<T[]>,
-    options: { expand: string[] } & Options<T>,
-  ): AsyncGenerator<AxiosResponse<T[]>>;
-  private fetchPages<T = ApiResponse>(
-    reqConfig: AxiosRequestConfig<T[]>,
-    options: { expand: undefined; fields: Required<Options<T>>['fields'] } & Options<T>,
+    options: { fields: Required<OptionsExtended<T>>['fields'] } & OptionsExtended<T>,
   ): AsyncGenerator<AxiosResponse<Pick<T, (typeof options)['fields'][number]>[]>>;
   private fetchPages<T = ApiResponse>(
     reqConfig: AxiosRequestConfig<T[]>,
-    options?: Options<T>,
+    options?: Options,
   ): AsyncGenerator<AxiosResponse<T[]>>;
   private async *fetchPages<T = ApiResponse>(
     reqConfig: AxiosRequestConfig<T[]>,
-    options?: Options<T>,
+    options?: Options,
   ): AsyncGenerator<AxiosResponse<T[]>> {
     const fallbackLimit = 20;
     const res = await this.fetch<T[]>(reqConfig, options);
@@ -223,17 +252,17 @@ export abstract class Service<ApiResponse = any> {
     const requestOffset = Number(res.headers['x-offset']) || 0;
 
     for (let offset = requestOffset + limit; offset < entityCount; offset += limit) {
-      yield this.fetch<T[]>(reqConfig, { ...options, offset } as Options<T>);
+      yield this.fetch<T[]>(reqConfig, { ...options, offset });
     }
   }
 
-  private async *listResponses<T = ApiResponse>(reqConfig: AxiosRequestConfig<T[]>, options?: Options<T>) {
+  private async *listResponses<T = ApiResponse>(reqConfig: AxiosRequestConfig<T[]>, options?: Options) {
     for await (const res of this.fetchPages<T>(reqConfig, options)) {
       yield* res.data;
     }
   }
 
-  iterator<T = ApiResponse>(reqConfig: AxiosRequestConfig<T[]>, options?: Options<T>) {
+  iterator<T = ApiResponse>(reqConfig: AxiosRequestConfig<T[]>, options?: Options) {
     return {
       [Symbol.asyncIterator]: () => this.listResponses<T>(reqConfig, options),
       byPage: () => this.fetchPages<T>(reqConfig, options),

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -109,9 +109,9 @@ export abstract class Service<ApiResponse = any> {
     return new URLSearchParams(reducedParams);
   }
 
-  fetch<T = ApiResponse, TOptions = ApiResponse>(
+  fetch<T = ApiResponse>(
     reqConfig: AxiosRequestConfig,
-    options?: Options<TOptions>,
+    options?: Options<T extends Array<unknown> ? T[number] : T>,
   ): Promise<AxiosResponse<T>> {
     const headers: Record<string, string> = {
       Authorization: RotaCloud.config.apiKey
@@ -169,7 +169,7 @@ export abstract class Service<ApiResponse = any> {
     options: Options<T> | undefined,
   ): AsyncGenerator<AxiosResponse<T[]>> {
     const fallbackLimit = 20;
-    const res = await this.fetch<T[], T>(reqConfig, options);
+    const res = await this.fetch<T[]>(reqConfig, options);
     yield res;
 
     const limit = Number(res.headers['x-limit']) || fallbackLimit;
@@ -177,7 +177,7 @@ export abstract class Service<ApiResponse = any> {
     const requestOffset = Number(res.headers['x-offset']) || 0;
 
     for (let offset = requestOffset + limit; offset < entityCount; offset += limit) {
-      yield this.fetch<T[], T>(reqConfig, { ...options, offset });
+      yield this.fetch<T[]>(reqConfig, { ...options, offset });
     }
   }
 

--- a/src/services/settings.service.ts
+++ b/src/services/settings.service.ts
@@ -5,7 +5,7 @@ import { Settings } from '../interfaces/index.js';
 
 import { SettingsQueryParams } from '../rotacloud.js';
 
-export class SettingsService extends Service {
+export class SettingsService extends Service<Settings> {
   private apiPath = '/settings';
 
   get(query: SettingsQueryParams): Promise<Settings>;
@@ -14,6 +14,6 @@ export class SettingsService extends Service {
   get(query: SettingsQueryParams, options?: Options) {
     return super
       .fetch<Settings>({ url: `${this.apiPath}`, params: query }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 }

--- a/src/services/shifts.service.ts
+++ b/src/services/shifts.service.ts
@@ -120,14 +120,14 @@ export class ShiftsService extends Service<Shift> {
   }
 
   delete(ids: number | number[]): Promise<number>;
-  delete(ids: number | number[], options: { rawResponse: true } & Options): Promise<AxiosResponse<any>>;
+  delete(ids: number | number[], options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   delete(ids: number | number[], options: Options): Promise<number>;
   delete(ids: number | number[], options?: Options) {
     const params: AxiosRequestConfig = Array.isArray(ids)
       ? { url: this.apiPath, data: { ids }, method: 'DELETE' }
       : { url: `${this.apiPath}/${ids}`, method: 'DELETE' };
 
-    return super.fetch<number>(params, options).then((res) => (options?.rawResponse ? res : res.status));
+    return super.fetch<void>(params, options).then((res) => (options?.rawResponse ? res : res.status));
   }
 
   acknowledge(data: number[]): Promise<number>;

--- a/src/services/shifts.service.ts
+++ b/src/services/shifts.service.ts
@@ -48,7 +48,7 @@ export class ShiftsService extends Service<Shift> {
   listAll(query: ShiftsQueryParams): Promise<Shift[]>;
   listAll<F extends keyof Shift>(
     query: ShiftsQueryParams,
-    options: { fields: F[] } & OptionsExtended<Shift[]>,
+    options: { fields: F[] } & OptionsExtended<Shift>,
   ): Promise<Pick<Shift, F>[]>;
   listAll(query: ShiftsQueryParams, options?: OptionsExtended<Shift>): Promise<Shift[]>;
   async listAll(query: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
@@ -62,7 +62,7 @@ export class ShiftsService extends Service<Shift> {
   listByPage(query: ShiftsQueryParams): AsyncGenerator<AxiosResponse<Shift[]>>;
   listByPage<F extends keyof Shift>(
     query: ShiftsQueryParams,
-    options: { fields: F[] } & OptionsExtended<Shift[]>,
+    options: { fields: F[] } & OptionsExtended<Shift>,
   ): AsyncGenerator<AxiosResponse<Pick<Shift, F>[]>>;
   listByPage(query: ShiftsQueryParams, options?: OptionsExtended<Shift>): AsyncGenerator<AxiosResponse<Shift[]>>;
   listByPage(query: ShiftsQueryParams, options?: OptionsExtended<Shift>) {

--- a/src/services/shifts.service.ts
+++ b/src/services/shifts.service.ts
@@ -35,23 +35,23 @@ export class ShiftsService extends Service<Shift> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query: ShiftsQueryParams): AsyncGenerator<Shift>;
+  list(query?: ShiftsQueryParams): AsyncGenerator<Shift>;
   list<F extends keyof Shift>(
     query: ShiftsQueryParams,
     options: { fields: F[] } & OptionsExtended<Shift>,
   ): AsyncGenerator<Pick<Shift, F>>;
-  list(query: ShiftsQueryParams, options?: OptionsExtended<Shift>): AsyncGenerator<Shift>;
-  async *list(query: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
+  list(query?: ShiftsQueryParams, options?: OptionsExtended<Shift>): AsyncGenerator<Shift>;
+  async *list(query?: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: ShiftsQueryParams): Promise<Shift[]>;
+  listAll(query?: ShiftsQueryParams): Promise<Shift[]>;
   listAll<F extends keyof Shift>(
     query: ShiftsQueryParams,
     options: { fields: F[] } & OptionsExtended<Shift>,
   ): Promise<Pick<Shift, F>[]>;
-  listAll(query: ShiftsQueryParams, options?: OptionsExtended<Shift>): Promise<Shift[]>;
-  async listAll(query: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
+  listAll(query?: ShiftsQueryParams, options?: OptionsExtended<Shift>): Promise<Shift[]>;
+  async listAll(query?: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
     const shifts = [] as Shift[];
     for await (const shift of this.list(query, options)) {
       shifts.push(shift);
@@ -59,13 +59,13 @@ export class ShiftsService extends Service<Shift> {
     return shifts;
   }
 
-  listByPage(query: ShiftsQueryParams): AsyncGenerator<AxiosResponse<Shift[]>>;
+  listByPage(query?: ShiftsQueryParams): AsyncGenerator<AxiosResponse<Shift[]>>;
   listByPage<F extends keyof Shift>(
     query: ShiftsQueryParams,
     options: { fields: F[] } & OptionsExtended<Shift>,
   ): AsyncGenerator<AxiosResponse<Pick<Shift, F>[]>>;
-  listByPage(query: ShiftsQueryParams, options?: OptionsExtended<Shift>): AsyncGenerator<AxiosResponse<Shift[]>>;
-  listByPage(query: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
+  listByPage(query?: ShiftsQueryParams, options?: OptionsExtended<Shift>): AsyncGenerator<AxiosResponse<Shift[]>>;
+  listByPage(query?: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
     return super.iterator<Shift>({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/shifts.service.ts
+++ b/src/services/shifts.service.ts
@@ -1,12 +1,12 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { Shift } from '../interfaces/index.js';
-import { Service, Options, RequirementsOf } from './index.js';
+import { Service, Options, RequirementsOf, OptionsExtended } from './index.js';
 
 import { ShiftsQueryParams } from '../interfaces/query-params/shifts-query-params.interface.js';
 
 type RequiredProps = 'end_time' | 'start_time' | 'location';
 
-export class ShiftsService extends Service {
+export class ShiftsService extends Service<Shift> {
   private apiPath = '/shifts';
 
   create(data: RequirementsOf<Shift, RequiredProps>): Promise<Shift>;
@@ -17,27 +17,41 @@ export class ShiftsService extends Service {
   create(data: RequirementsOf<Shift, RequiredProps>, options: Options): Promise<Shift>;
   create(data: RequirementsOf<Shift, RequiredProps>, options?: Options) {
     return super
-      .fetch<Shift>({ url: this.apiPath, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<Shift>({ url: this.apiPath, data, method: 'POST' }, options)
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   get(id: number): Promise<Shift>;
-  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<Shift, any>>;
-  get(id: number, options: Options): Promise<Shift>;
-  get(id: number, options?: Options) {
+  get<F extends keyof Shift>(
+    id: number,
+    options: { fields: F[]; rawResponse: true } & OptionsExtended<Shift>,
+  ): Promise<AxiosResponse<Pick<Shift, F>>>;
+  get<F extends keyof Shift>(id: number, options: { fields: F[] } & OptionsExtended<Shift>): Promise<Pick<Shift, F>>;
+  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<Shift>>;
+  get(id: number, options?: OptionsExtended<Shift>): Promise<Shift>;
+  get(id: number, options?: OptionsExtended<Shift>) {
     return super
       .fetch<Shift>({ url: `${this.apiPath}/${id}` }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  async *list(query: ShiftsQueryParams, options?: Options) {
-    for await (const res of super.iterator<Shift>({ url: this.apiPath, params: query }, options)) {
-      yield res;
-    }
+  list(query: ShiftsQueryParams): AsyncGenerator<Shift>;
+  list<F extends keyof Shift>(
+    query: ShiftsQueryParams,
+    options: { fields: F[] } & OptionsExtended<Shift>,
+  ): AsyncGenerator<Pick<Shift, F>>;
+  list(query: ShiftsQueryParams, options?: OptionsExtended<Shift>): AsyncGenerator<Shift>;
+  async *list(query: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
+    yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: ShiftsQueryParams, options?: Options): Promise<Shift[]>;
-  async listAll(query: ShiftsQueryParams, options?: Options) {
+  listAll(query: ShiftsQueryParams): Promise<Shift[]>;
+  listAll<F extends keyof Shift>(
+    query: ShiftsQueryParams,
+    options: { fields: F[] } & OptionsExtended<Shift[]>,
+  ): Promise<Pick<Shift, F>[]>;
+  listAll(query: ShiftsQueryParams, options?: OptionsExtended<Shift>): Promise<Shift[]>;
+  async listAll(query: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
     const shifts = [] as Shift[];
     for await (const shift of this.list(query, options)) {
       shifts.push(shift);
@@ -45,7 +59,13 @@ export class ShiftsService extends Service {
     return shifts;
   }
 
-  listByPage(query: ShiftsQueryParams, options?: Options) {
+  listByPage(query: ShiftsQueryParams): AsyncGenerator<AxiosResponse<Shift[]>>;
+  listByPage<F extends keyof Shift>(
+    query: ShiftsQueryParams,
+    options: { fields: F[] } & OptionsExtended<Shift[]>,
+  ): AsyncGenerator<AxiosResponse<Pick<Shift, F>[]>>;
+  listByPage(query: ShiftsQueryParams, options?: OptionsExtended<Shift>): AsyncGenerator<AxiosResponse<Shift[]>>;
+  listByPage(query: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
     return super.iterator<Shift>({ url: this.apiPath, params: query }, options).byPage();
   }
 
@@ -65,20 +85,26 @@ export class ShiftsService extends Service {
   update(shifts: RequirementsOf<Shift, 'id'> | RequirementsOf<Shift, 'id'>[], options?: Options) {
     if (!Array.isArray(shifts)) {
       return super
-        .fetch<Shift>({
-          url: `${this.apiPath}/${shifts.id}`,
-          data: shifts,
-          method: 'POST',
-        })
+        .fetch<Shift>(
+          {
+            url: `${this.apiPath}/${shifts.id}`,
+            data: shifts,
+            method: 'POST',
+          },
+          options,
+        )
         .then((res) => (options?.rawResponse ? res : res.data));
     }
 
     return super
-      .fetch<{ code: number; data?: Shift; error?: string }[]>({
-        url: this.apiPath,
-        data: shifts,
-        method: 'POST',
-      })
+      .fetch<{ code: number; data?: Shift; error?: string }[]>(
+        {
+          url: this.apiPath,
+          data: shifts,
+          method: 'POST',
+        },
+        options,
+      )
       .then((res) => {
         if (options?.rawResponse) return res;
 
@@ -94,40 +120,40 @@ export class ShiftsService extends Service {
   }
 
   delete(ids: number | number[]): Promise<number>;
-  delete(ids: number | number[], options: { rawResponse: true } & Options): Promise<AxiosResponse<any, any>>;
+  delete(ids: number | number[], options: { rawResponse: true } & Options): Promise<AxiosResponse<any>>;
   delete(ids: number | number[], options: Options): Promise<number>;
   delete(ids: number | number[], options?: Options) {
     const params: AxiosRequestConfig = Array.isArray(ids)
       ? { url: this.apiPath, data: { ids }, method: 'DELETE' }
       : { url: `${this.apiPath}/${ids}`, method: 'DELETE' };
 
-    return super.fetch<Shift>(params).then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+    return super.fetch<number>(params, options).then((res) => (options?.rawResponse ? res : res.status));
   }
 
   acknowledge(data: number[]): Promise<number>;
-  acknowledge(data: number[], options: { rawResponse: true } & Options): Promise<AxiosResponse<any, any>>;
+  acknowledge(data: number[], options: { rawResponse: true } & Options): Promise<AxiosResponse<any>>;
   acknowledge(data: number[], options: Options): Promise<number>;
   acknowledge(data: number[], options?: Options) {
     return super
-      .fetch<Shift>({ url: '/shifts_acknowledged', data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+      .fetch<Shift>({ url: '/shifts_acknowledged', data, method: 'POST' }, options)
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 
   publish(data: { shifts: number[] }): Promise<number>;
-  publish(data: { shifts: number[] }, options: { rawResponse: true } & Options): Promise<AxiosResponse<any, any>>;
+  publish(data: { shifts: number[] }, options: { rawResponse: true } & Options): Promise<AxiosResponse<any>>;
   publish(data: { shifts: number[] }, options: Options): Promise<number>;
   publish(data: { shifts: number[] }, options?: Options) {
     return super
-      .fetch<Shift>({ url: '/shifts_published', data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+      .fetch<Shift>({ url: '/shifts_published', data, method: 'POST' }, options)
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 
   unpublish(data: { shifts: number[] }): Promise<number>;
-  unpublish(data: { shifts: number[] }, options: { rawResponse: true } & Options): Promise<AxiosResponse<any, any>>;
+  unpublish(data: { shifts: number[] }, options: { rawResponse: true } & Options): Promise<AxiosResponse<any>>;
   unpublish(data: { shifts: number[] }, options: Options): Promise<number>;
   unpublish(data: { shifts: number[] }, options?: Options) {
     return super
-      .fetch<Shift>({ url: '/shifts_published', data, method: 'DELETE' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+      .fetch<Shift>({ url: '/shifts_published', data, method: 'DELETE' }, options)
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/shifts.service.ts
+++ b/src/services/shifts.service.ts
@@ -35,23 +35,23 @@ export class ShiftsService extends Service<Shift> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query?: ShiftsQueryParams): AsyncGenerator<Shift>;
+  list(query: ShiftsQueryParams): AsyncGenerator<Shift>;
   list<F extends keyof Shift>(
     query: ShiftsQueryParams,
     options: { fields: F[] } & OptionsExtended<Shift>,
   ): AsyncGenerator<Pick<Shift, F>>;
-  list(query?: ShiftsQueryParams, options?: OptionsExtended<Shift>): AsyncGenerator<Shift>;
-  async *list(query?: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
+  list(query: ShiftsQueryParams, options?: OptionsExtended<Shift>): AsyncGenerator<Shift>;
+  async *list(query: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query?: ShiftsQueryParams): Promise<Shift[]>;
+  listAll(query: ShiftsQueryParams): Promise<Shift[]>;
   listAll<F extends keyof Shift>(
     query: ShiftsQueryParams,
     options: { fields: F[] } & OptionsExtended<Shift>,
   ): Promise<Pick<Shift, F>[]>;
-  listAll(query?: ShiftsQueryParams, options?: OptionsExtended<Shift>): Promise<Shift[]>;
-  async listAll(query?: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
+  listAll(query: ShiftsQueryParams, options?: OptionsExtended<Shift>): Promise<Shift[]>;
+  async listAll(query: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
     const shifts = [] as Shift[];
     for await (const shift of this.list(query, options)) {
       shifts.push(shift);
@@ -59,13 +59,13 @@ export class ShiftsService extends Service<Shift> {
     return shifts;
   }
 
-  listByPage(query?: ShiftsQueryParams): AsyncGenerator<AxiosResponse<Shift[]>>;
+  listByPage(query: ShiftsQueryParams): AsyncGenerator<AxiosResponse<Shift[]>>;
   listByPage<F extends keyof Shift>(
     query: ShiftsQueryParams,
     options: { fields: F[] } & OptionsExtended<Shift>,
   ): AsyncGenerator<AxiosResponse<Pick<Shift, F>[]>>;
-  listByPage(query?: ShiftsQueryParams, options?: OptionsExtended<Shift>): AsyncGenerator<AxiosResponse<Shift[]>>;
-  listByPage(query?: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
+  listByPage(query: ShiftsQueryParams, options?: OptionsExtended<Shift>): AsyncGenerator<AxiosResponse<Shift[]>>;
+  listByPage(query: ShiftsQueryParams, options?: OptionsExtended<Shift>) {
     return super.iterator<Shift>({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/terminals-active.service.ts
+++ b/src/services/terminals-active.service.ts
@@ -77,11 +77,11 @@ export class TerminalsActiveService extends Service<Terminal> {
   }
 
   closeTerminal(id: number): Promise<number>;
-  closeTerminal(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<any>>;
+  closeTerminal(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   closeTerminal(id: number, options: Options): Promise<number>;
   closeTerminal(id: number, options?: Options) {
     return super
-      .fetch({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .fetch<void>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/terminals-active.service.ts
+++ b/src/services/terminals-active.service.ts
@@ -55,9 +55,7 @@ export class TerminalsActiveService extends Service<Terminal> {
   }
 
   listAll(): Promise<Terminal[]>;
-  listAll<F extends keyof Terminal>(
-    options: { fields: F[] } & OptionsExtended<Terminal[]>,
-  ): Promise<Pick<Terminal, F>[]>;
+  listAll<F extends keyof Terminal>(options: { fields: F[] } & OptionsExtended<Terminal>): Promise<Pick<Terminal, F>[]>;
   listAll(options?: OptionsExtended<Terminal>): Promise<Terminal[]>;
   async listAll(options?: Options) {
     const users = [] as Terminal[];
@@ -69,7 +67,7 @@ export class TerminalsActiveService extends Service<Terminal> {
 
   listByPage(): AsyncGenerator<AxiosResponse<Terminal[]>>;
   listByPage<F extends keyof Terminal>(
-    options: { fields: F[] } & OptionsExtended<Terminal[]>,
+    options: { fields: F[] } & OptionsExtended<Terminal>,
   ): AsyncGenerator<AxiosResponse<Pick<Terminal, F>[]>>;
   listByPage(options?: OptionsExtended<Terminal>): AsyncGenerator<AxiosResponse<Terminal[]>>;
   listByPage(options?: Options) {

--- a/src/services/terminals-active.service.ts
+++ b/src/services/terminals-active.service.ts
@@ -57,7 +57,7 @@ export class TerminalsActiveService extends Service<Terminal> {
   listAll(): Promise<Terminal[]>;
   listAll<F extends keyof Terminal>(options: { fields: F[] } & OptionsExtended<Terminal>): Promise<Pick<Terminal, F>[]>;
   listAll(options?: OptionsExtended<Terminal>): Promise<Terminal[]>;
-  async listAll(options?: Options) {
+  async listAll(options?: OptionsExtended<Terminal>) {
     const users = [] as Terminal[];
     for await (const user of this.list(options)) {
       users.push(user);
@@ -70,7 +70,7 @@ export class TerminalsActiveService extends Service<Terminal> {
     options: { fields: F[] } & OptionsExtended<Terminal>,
   ): AsyncGenerator<AxiosResponse<Pick<Terminal, F>[]>>;
   listByPage(options?: OptionsExtended<Terminal>): AsyncGenerator<AxiosResponse<Terminal[]>>;
-  listByPage(options?: Options) {
+  listByPage(options?: OptionsExtended<Terminal>) {
     return super.iterator({ url: this.apiPath }, options).byPage();
   }
 

--- a/src/services/terminals.service.ts
+++ b/src/services/terminals.service.ts
@@ -67,14 +67,14 @@ export class TerminalsService extends Service<Terminal> {
     options: { fields: F[] } & OptionsExtended<Terminal>,
   ): AsyncGenerator<Pick<Terminal, F>>;
   list(options?: OptionsExtended<Terminal>): AsyncGenerator<Terminal>;
-  async *list(options?: Options) {
+  async *list(options?: OptionsExtended<Terminal>) {
     yield* super.iterator({ url: this.apiPath }, options);
   }
 
   listAll(): Promise<Terminal[]>;
   listAll<F extends keyof Terminal>(options: { fields: F[] } & OptionsExtended<Terminal>): Promise<Pick<Terminal, F>[]>;
   listAll(options?: OptionsExtended<Terminal>): Promise<Terminal[]>;
-  async listAll(options?: Options) {
+  async listAll(options?: OptionsExtended<Terminal>) {
     const users = [] as Terminal[];
     for await (const user of this.list(options)) {
       users.push(user);
@@ -87,7 +87,7 @@ export class TerminalsService extends Service<Terminal> {
     options: { fields: F[] } & OptionsExtended<Terminal>,
   ): AsyncGenerator<AxiosResponse<Pick<Terminal, F>[]>>;
   listByPage(options?: OptionsExtended<Terminal>): AsyncGenerator<AxiosResponse<Terminal[]>>;
-  listByPage(options?: Options) {
+  listByPage(options?: OptionsExtended<Terminal>) {
     return super.iterator({ url: this.apiPath }, options).byPage();
   }
 }

--- a/src/services/terminals.service.ts
+++ b/src/services/terminals.service.ts
@@ -72,9 +72,7 @@ export class TerminalsService extends Service<Terminal> {
   }
 
   listAll(): Promise<Terminal[]>;
-  listAll<F extends keyof Terminal>(
-    options: { fields: F[] } & OptionsExtended<Terminal[]>,
-  ): Promise<Pick<Terminal, F>[]>;
+  listAll<F extends keyof Terminal>(options: { fields: F[] } & OptionsExtended<Terminal>): Promise<Pick<Terminal, F>[]>;
   listAll(options?: OptionsExtended<Terminal>): Promise<Terminal[]>;
   async listAll(options?: Options) {
     const users = [] as Terminal[];
@@ -86,7 +84,7 @@ export class TerminalsService extends Service<Terminal> {
 
   listByPage(): AsyncGenerator<AxiosResponse<Terminal[]>>;
   listByPage<F extends keyof Terminal>(
-    options: { fields: F[] } & OptionsExtended<Terminal[]>,
+    options: { fields: F[] } & OptionsExtended<Terminal>,
   ): AsyncGenerator<AxiosResponse<Pick<Terminal, F>[]>>;
   listByPage(options?: OptionsExtended<Terminal>): AsyncGenerator<AxiosResponse<Terminal[]>>;
   listByPage(options?: Options) {

--- a/src/services/terminals.service.ts
+++ b/src/services/terminals.service.ts
@@ -54,11 +54,11 @@ export class TerminalsService extends Service<Terminal> {
   }
 
   closeTerminal(id: number): Promise<number>;
-  closeTerminal(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  closeTerminal(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   closeTerminal(id: number, options: Options): Promise<number>;
   closeTerminal(id: number, options?: Options) {
     return super
-      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
+      .fetch<void>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 

--- a/src/services/terminals.service.ts
+++ b/src/services/terminals.service.ts
@@ -1,10 +1,10 @@
 import { AxiosResponse } from 'axios';
 import { Terminal } from '../interfaces/index.js';
-import { Service, Options, RequirementsOf } from './index.js';
+import { Service, Options, RequirementsOf, OptionsExtended } from './index.js';
 
 type RequiredProps = 'name' | 'timezone';
 
-export class TerminalsService extends Service {
+export class TerminalsService extends Service<Terminal> {
   private apiPath = '/terminals';
 
   create(data: RequirementsOf<Terminal, RequiredProps>): Promise<Terminal>;
@@ -16,16 +16,24 @@ export class TerminalsService extends Service {
   create(data: RequirementsOf<Terminal, RequiredProps>, options?: Options) {
     return super
       .fetch<Terminal>({ url: this.apiPath, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   get(id: number): Promise<Terminal>;
-  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<Terminal, any>>;
-  get(id: number, options: Options): Promise<Terminal>;
+  get<F extends keyof Terminal>(
+    id: number,
+    options: { fields: F[]; rawResponse: true } & OptionsExtended<Terminal>,
+  ): Promise<AxiosResponse<Pick<Terminal, F>>>;
+  get<F extends keyof Terminal>(
+    id: number,
+    options: { fields: F[] } & OptionsExtended<Terminal>,
+  ): Promise<Pick<Terminal, F>>;
+  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<Terminal>>;
+  get(id: number, options?: OptionsExtended<Terminal>): Promise<Terminal>;
   get(id: number, options?: Options) {
     return super
       .fetch<Terminal>({ url: `${this.apiPath}/${id}` }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   update(id: number, data: Partial<Terminal>): Promise<Terminal>;
@@ -42,25 +50,32 @@ export class TerminalsService extends Service {
         data,
         method: 'POST',
       })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   closeTerminal(id: number): Promise<number>;
-  closeTerminal(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number, any>>;
+  closeTerminal(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
   closeTerminal(id: number, options: Options): Promise<number>;
   closeTerminal(id: number, options?: Options) {
     return super
-      .fetch({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 
+  list(): AsyncGenerator<Terminal>;
+  list<F extends keyof Terminal>(
+    options: { fields: F[] } & OptionsExtended<Terminal>,
+  ): AsyncGenerator<Pick<Terminal, F>>;
+  list(options?: OptionsExtended<Terminal>): AsyncGenerator<Terminal>;
   async *list(options?: Options) {
-    for await (const res of super.iterator<Terminal>({ url: this.apiPath }, options)) {
-      yield res;
-    }
+    yield* super.iterator({ url: this.apiPath }, options);
   }
 
-  listAll(options?: Options): Promise<Terminal[]>;
+  listAll(): Promise<Terminal[]>;
+  listAll<F extends keyof Terminal>(
+    options: { fields: F[] } & OptionsExtended<Terminal[]>,
+  ): Promise<Pick<Terminal, F>[]>;
+  listAll(options?: OptionsExtended<Terminal>): Promise<Terminal[]>;
   async listAll(options?: Options) {
     const users = [] as Terminal[];
     for await (const user of this.list(options)) {
@@ -69,7 +84,12 @@ export class TerminalsService extends Service {
     return users;
   }
 
+  listByPage(): AsyncGenerator<AxiosResponse<Terminal[]>>;
+  listByPage<F extends keyof Terminal>(
+    options: { fields: F[] } & OptionsExtended<Terminal[]>,
+  ): AsyncGenerator<AxiosResponse<Pick<Terminal, F>[]>>;
+  listByPage(options?: OptionsExtended<Terminal>): AsyncGenerator<AxiosResponse<Terminal[]>>;
   listByPage(options?: Options) {
-    return super.iterator<Terminal>({ url: this.apiPath }, options).byPage();
+    return super.iterator({ url: this.apiPath }, options).byPage();
   }
 }

--- a/src/services/time-zone.service.ts
+++ b/src/services/time-zone.service.ts
@@ -3,7 +3,7 @@ import { Service, Options } from './index.js';
 
 import { TimeZone } from '../interfaces/index.js';
 
-export class TimeZoneService extends Service {
+export class TimeZoneService extends Service<TimeZone> {
   private apiPath = '/timezones';
 
   get(id: number): Promise<TimeZone>;
@@ -12,13 +12,11 @@ export class TimeZoneService extends Service {
   get(id: number, options?: Options) {
     return super
       .fetch<TimeZone>({ url: `${this.apiPath}/${id}` }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   async *list(options?: Options) {
-    for await (const res of super.iterator<TimeZone>({ url: this.apiPath }, options)) {
-      yield res;
-    }
+    yield* super.iterator({ url: this.apiPath }, options);
   }
 
   listAll(options?: Options): Promise<TimeZone[]>;
@@ -31,6 +29,6 @@ export class TimeZoneService extends Service {
   }
 
   listByPage(options?: Options) {
-    return super.iterator<TimeZone>({ url: this.apiPath }, options).byPage();
+    return super.iterator({ url: this.apiPath }, options).byPage();
   }
 }

--- a/src/services/toil-accruals.service.ts
+++ b/src/services/toil-accruals.service.ts
@@ -17,7 +17,7 @@ export class ToilAccrualsService extends Service {
   create(data: RequirementsOf<ToilAccrual, RequiredProps>, options?: Options) {
     return super
       .fetch<ToilAccrual>({ url: this.apiPath, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   get(id: number): Promise<ToilAccrual>;
@@ -26,13 +26,11 @@ export class ToilAccrualsService extends Service {
   get(id: number, options?: Options) {
     return super
       .fetch<ToilAccrual>({ url: `${this.apiPath}/${id}` }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   async *list(query: ToilAccrualsQueryParams, options?: Options) {
-    for await (const res of super.iterator<ToilAccrual>({ url: this.apiPath, params: query }, options)) {
-      yield res;
-    }
+    yield* super.iterator<ToilAccrual>({ url: this.apiPath, params: query }, options);
   }
 
   async listAll(query: ToilAccrualsQueryParams, options?: Options): Promise<ToilAccrual[]> {
@@ -53,6 +51,6 @@ export class ToilAccrualsService extends Service {
   delete(id: number, options?: Options) {
     return super
       .fetch<ToilAccrual>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/toil-accruals.service.ts
+++ b/src/services/toil-accruals.service.ts
@@ -46,11 +46,11 @@ export class ToilAccrualsService extends Service {
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<any, any>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   delete(id: number, options: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<ToilAccrual>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
+      .fetch<void>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/toil-accruals.service.ts
+++ b/src/services/toil-accruals.service.ts
@@ -29,11 +29,11 @@ export class ToilAccrualsService extends Service {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  async *list(query: ToilAccrualsQueryParams, options?: Options) {
+  async *list(query?: ToilAccrualsQueryParams, options?: Options) {
     yield* super.iterator<ToilAccrual>({ url: this.apiPath, params: query }, options);
   }
 
-  async listAll(query: ToilAccrualsQueryParams, options?: Options): Promise<ToilAccrual[]> {
+  async listAll(query?: ToilAccrualsQueryParams, options?: Options): Promise<ToilAccrual[]> {
     const toilAccruals = [] as ToilAccrual[];
     for await (const accrual of this.list(query, options)) {
       toilAccruals.push(accrual);
@@ -41,7 +41,7 @@ export class ToilAccrualsService extends Service {
     return toilAccruals;
   }
 
-  listByPage(query: ToilAccrualsQueryParams, options?: Options) {
+  listByPage(query?: ToilAccrualsQueryParams, options?: Options) {
     return super.iterator<ToilAccrual>({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/toil-allowance.service.ts
+++ b/src/services/toil-allowance.service.ts
@@ -2,13 +2,11 @@ import { Options, Service } from './service';
 import { ToilAllowanceQueryParams } from '../interfaces/query-params/toil-allowance-query-params.interface';
 import { ToilAllowance } from '../interfaces/toil-allowance.interface';
 
-export class ToilAllowanceService extends Service {
+export class ToilAllowanceService extends Service<ToilAllowance> {
   private apiPath = '/toil_allowance';
 
   async *list(year: number, query: ToilAllowanceQueryParams, options?: Options) {
-    for await (const res of super.iterator<ToilAllowance>({ url: `${this.apiPath}/${year}`, params: query }, options)) {
-      yield res;
-    }
+    yield* super.iterator({ url: `${this.apiPath}/${year}`, params: query }, options);
   }
 
   async listAll(year: number, query: ToilAllowanceQueryParams, options?: Options): Promise<ToilAllowance[]> {
@@ -20,6 +18,6 @@ export class ToilAllowanceService extends Service {
   }
 
   listByPage(year: number, query: ToilAllowanceQueryParams, options?: Options) {
-    return super.iterator<ToilAllowance[]>({ url: `${this.apiPath}/${year}`, params: query }, options).byPage();
+    return super.iterator({ url: `${this.apiPath}/${year}`, params: query }, options).byPage();
   }
 }

--- a/src/services/users-clock-in.service.ts
+++ b/src/services/users-clock-in.service.ts
@@ -41,7 +41,7 @@ export class UsersClockInService extends Service<UserClockedIn> {
     options: { fields: F[] } & OptionsExtended<UserClockedIn>,
   ): AsyncGenerator<Pick<UserClockedIn, F>>;
   list(options?: OptionsExtended<UserClockedIn>): AsyncGenerator<UserClockedIn>;
-  async *list(options?: Options) {
+  async *list(options?: OptionsExtended<UserClockedIn>) {
     for await (const res of super.iterator<UserClockedIn>({ url: this.apiPath }, options)) {
       yield res;
     }
@@ -52,7 +52,7 @@ export class UsersClockInService extends Service<UserClockedIn> {
     options: { fields: F[] } & OptionsExtended<UserClockedIn>,
   ): Promise<Pick<UserClockedIn, F>[]>;
   listAll(options?: OptionsExtended<UserClockedIn>): Promise<UserClockedIn[]>;
-  async listAll(options?: Options) {
+  async listAll(options?: OptionsExtended<UserClockedIn>) {
     const users = [] as UserClockedIn[];
     for await (const user of this.list(options)) {
       users.push(user);
@@ -65,7 +65,7 @@ export class UsersClockInService extends Service<UserClockedIn> {
     options: { fields: F[] } & OptionsExtended<UserClockedIn>,
   ): AsyncGenerator<AxiosResponse<Pick<UserClockedIn, F>[]>>;
   listByPage(options?: OptionsExtended<UserClockedIn>): AsyncGenerator<AxiosResponse<UserClockedIn[]>>;
-  listByPage(options?: Options) {
+  listByPage(options?: OptionsExtended<UserClockedIn>) {
     return super.iterator<UserClockedIn>({ url: this.apiPath }, options).byPage();
   }
 

--- a/src/services/users-clock-in.service.ts
+++ b/src/services/users-clock-in.service.ts
@@ -28,12 +28,12 @@ export class UsersClockInService extends Service<UserClockedIn> {
   private apiPath = '/users_clocked_in';
 
   getClockedInUser(id: number): Promise<UserClockedIn>;
-  getClockedInUser(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<UserClockedIn, any>>;
+  getClockedInUser(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<UserClockedIn>>;
   getClockedInUser(id: number, options: Options): Promise<UserClockedIn>;
   getClockedInUser(id: number, options?: Options) {
     return super
       .fetch<UserClockedIn>({ url: `${this.apiPath}/${id}` }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   list(): AsyncGenerator<UserClockedIn>;
@@ -73,12 +73,12 @@ export class UsersClockInService extends Service<UserClockedIn> {
   clockIn(
     data: RequirementsOf<UserClockIn, RequiredPropsClockIn>,
     options: { rawResponse: true } & Options,
-  ): Promise<AxiosResponse<UserClockedIn, any>>;
+  ): Promise<AxiosResponse<UserClockedIn>>;
   clockIn(data: RequirementsOf<UserClockIn, RequiredPropsClockIn>, options: Options): Promise<UserClockedIn>;
   clockIn(data: RequirementsOf<UserClockIn, RequiredPropsClockIn>, options?: Options) {
     return super
       .fetch<UserClockedIn>({ url: this.apiPath, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   clockOut(id: number, data: UserClockOut): Promise<UserClockedOut>;
@@ -86,12 +86,12 @@ export class UsersClockInService extends Service<UserClockedIn> {
     id: number,
     data: UserClockOut,
     options: { rawResponse: true } & Options,
-  ): Promise<AxiosResponse<UserClockedOut, any>>;
+  ): Promise<AxiosResponse<UserClockedOut>>;
   clockOut(id: number, data: UserClockOut, options: Options): Promise<UserClockedOut>;
   clockOut(id: number, data: UserClockOut, options?: Options) {
     return super
       .fetch<UserClockedOut>({ url: `${this.apiPath}/${id}`, data, method: 'DELETE' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   startBreak(id: number, data: RequirementsOf<UserBreakRequest, RequiredPropsBreak>): Promise<UserBreak>;
@@ -99,7 +99,7 @@ export class UsersClockInService extends Service<UserClockedIn> {
     id: number,
     data: RequirementsOf<UserBreakRequest, RequiredPropsBreak>,
     options: { rawResponse: true } & Options,
-  ): Promise<AxiosResponse<UserBreak, any>>;
+  ): Promise<AxiosResponse<UserBreak>>;
   startBreak(
     id: number,
     data: RequirementsOf<UserBreakRequest, RequiredPropsBreak>,
@@ -108,7 +108,7 @@ export class UsersClockInService extends Service<UserClockedIn> {
   startBreak(id: number, data: RequirementsOf<UserBreakRequest, RequiredPropsBreak>, options?: Options) {
     return super
       .fetch<UserBreak>({ url: `${this.apiPath}/${id}`, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   endBreak(id: number, data: RequirementsOf<UserBreakRequest, RequiredPropsBreak>): Promise<UserBreak>;
@@ -116,7 +116,7 @@ export class UsersClockInService extends Service<UserClockedIn> {
     id: number,
     data: RequirementsOf<UserBreakRequest, RequiredPropsBreak>,
     options: { rawResponse: true } & Options,
-  ): Promise<AxiosResponse<UserBreak, any>>;
+  ): Promise<AxiosResponse<UserBreak>>;
   endBreak(
     id: number,
     data: RequirementsOf<UserBreakRequest, RequiredPropsBreak>,
@@ -125,6 +125,6 @@ export class UsersClockInService extends Service<UserClockedIn> {
   endBreak(id: number, data: RequirementsOf<UserBreakRequest, RequiredPropsBreak>, options?: Options) {
     return super
       .fetch<UserBreak>({ url: `${this.apiPath}/${id}`, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 }

--- a/src/services/users-clock-in.service.ts
+++ b/src/services/users-clock-in.service.ts
@@ -49,7 +49,7 @@ export class UsersClockInService extends Service<UserClockedIn> {
 
   listAll(): Promise<UserClockedIn[]>;
   listAll<F extends keyof UserClockedIn>(
-    options: { fields: F[] } & OptionsExtended<UserClockedIn[]>,
+    options: { fields: F[] } & OptionsExtended<UserClockedIn>,
   ): Promise<Pick<UserClockedIn, F>[]>;
   listAll(options?: OptionsExtended<UserClockedIn>): Promise<UserClockedIn[]>;
   async listAll(options?: Options) {
@@ -62,7 +62,7 @@ export class UsersClockInService extends Service<UserClockedIn> {
 
   listByPage(): AsyncGenerator<AxiosResponse<UserClockedIn[]>>;
   listByPage<F extends keyof UserClockedIn>(
-    options: { fields: F[] } & OptionsExtended<UserClockedIn[]>,
+    options: { fields: F[] } & OptionsExtended<UserClockedIn>,
   ): AsyncGenerator<AxiosResponse<Pick<UserClockedIn, F>[]>>;
   listByPage(options?: OptionsExtended<UserClockedIn>): AsyncGenerator<AxiosResponse<UserClockedIn[]>>;
   listByPage(options?: Options) {

--- a/src/services/users-clock-in.service.ts
+++ b/src/services/users-clock-in.service.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { UserBreak, UserClockedIn, UserClockedOut, TerminalLocation } from '../interfaces/index.js';
-import { Service, Options, RequirementsOf } from './index.js';
+import { Service, Options, RequirementsOf, OptionsExtended } from './index.js';
 
 interface UserClockIn {
   method: string;
@@ -24,7 +24,7 @@ interface UserBreakRequest {
 type RequiredPropsClockIn = 'method';
 type RequiredPropsBreak = 'method' | 'action';
 
-export class UsersClockInService extends Service {
+export class UsersClockInService extends Service<UserClockedIn> {
   private apiPath = '/users_clocked_in';
 
   getClockedInUser(id: number): Promise<UserClockedIn>;
@@ -36,13 +36,22 @@ export class UsersClockInService extends Service {
       .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
   }
 
+  list(): AsyncGenerator<UserClockedIn>;
+  list<F extends keyof UserClockedIn>(
+    options: { fields: F[] } & OptionsExtended<UserClockedIn>,
+  ): AsyncGenerator<Pick<UserClockedIn, F>>;
+  list(options?: OptionsExtended<UserClockedIn>): AsyncGenerator<UserClockedIn>;
   async *list(options?: Options) {
     for await (const res of super.iterator<UserClockedIn>({ url: this.apiPath }, options)) {
       yield res;
     }
   }
 
-  listAll(options?: Options): Promise<UserClockedIn[]>;
+  listAll(): Promise<UserClockedIn[]>;
+  listAll<F extends keyof UserClockedIn>(
+    options: { fields: F[] } & OptionsExtended<UserClockedIn[]>,
+  ): Promise<Pick<UserClockedIn, F>[]>;
+  listAll(options?: OptionsExtended<UserClockedIn>): Promise<UserClockedIn[]>;
   async listAll(options?: Options) {
     const users = [] as UserClockedIn[];
     for await (const user of this.list(options)) {
@@ -51,6 +60,11 @@ export class UsersClockInService extends Service {
     return users;
   }
 
+  listByPage(): AsyncGenerator<AxiosResponse<UserClockedIn[]>>;
+  listByPage<F extends keyof UserClockedIn>(
+    options: { fields: F[] } & OptionsExtended<UserClockedIn[]>,
+  ): AsyncGenerator<AxiosResponse<Pick<UserClockedIn, F>[]>>;
+  listByPage(options?: OptionsExtended<UserClockedIn>): AsyncGenerator<AxiosResponse<UserClockedIn[]>>;
   listByPage(options?: Options) {
     return super.iterator<UserClockedIn>({ url: this.apiPath }, options).byPage();
   }

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -35,23 +35,23 @@ export class UsersService extends Service<User> {
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  list(query: UsersQueryParams): AsyncGenerator<User>;
+  list(query?: UsersQueryParams): AsyncGenerator<User>;
   list<F extends keyof User>(
     query: UsersQueryParams,
     options: { fields: F[] } & OptionsExtended<User>,
   ): AsyncGenerator<Pick<User, F>>;
-  list(query: UsersQueryParams, options?: OptionsExtended<User>): AsyncGenerator<User>;
-  async *list(query: UsersQueryParams, options?: OptionsExtended<User>) {
+  list(query?: UsersQueryParams, options?: OptionsExtended<User>): AsyncGenerator<User>;
+  async *list(query?: UsersQueryParams, options?: OptionsExtended<User>) {
     yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: UsersQueryParams): Promise<User[]>;
+  listAll(query?: UsersQueryParams): Promise<User[]>;
   listAll<F extends keyof User>(
     query: UsersQueryParams,
     options: { fields: F[] } & OptionsExtended<User>,
   ): Promise<Pick<User, F>[]>;
-  listAll(query: UsersQueryParams, options?: OptionsExtended<User>): Promise<User[]>;
-  async listAll(query: UsersQueryParams, options?: OptionsExtended<User>) {
+  listAll(query?: UsersQueryParams, options?: OptionsExtended<User>): Promise<User[]>;
+  async listAll(query?: UsersQueryParams, options?: OptionsExtended<User>) {
     const users = [] as User[];
     for await (const user of this.list(query, options)) {
       users.push(user);
@@ -59,13 +59,13 @@ export class UsersService extends Service<User> {
     return users;
   }
 
-  listByPage(query: UsersQueryParams): AsyncGenerator<AxiosResponse<User[]>>;
+  listByPage(query?: UsersQueryParams): AsyncGenerator<AxiosResponse<User[]>>;
   listByPage<F extends keyof User>(
     query: UsersQueryParams,
     options: { fields: F[] } & OptionsExtended<User>,
   ): AsyncGenerator<AxiosResponse<Pick<User, F>[]>>;
-  listByPage(query: UsersQueryParams, options?: OptionsExtended<User>): AsyncGenerator<AxiosResponse<User[]>>;
-  listByPage(query: UsersQueryParams, options?: OptionsExtended<User>) {
+  listByPage(query?: UsersQueryParams, options?: OptionsExtended<User>): AsyncGenerator<AxiosResponse<User[]>>;
+  listByPage(query?: UsersQueryParams, options?: OptionsExtended<User>) {
     return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -6,38 +6,38 @@ import { UsersQueryParams } from '../interfaces/query-params/users-query-params.
 
 type RequiredProps = 'first_name' | 'last_name';
 
-export class UsersService extends Service {
+export class UsersService extends Service<User> {
   private apiPath = '/users';
 
   create(data: RequirementsOf<User, RequiredProps>): Promise<User>;
   create(
     data: RequirementsOf<User, RequiredProps>,
-    options: { rawResponse: true } & Options,
+    options: { rawResponse: true } & Options<User>,
   ): Promise<AxiosResponse<User, any>>;
-  create(data: RequirementsOf<User, RequiredProps>, options: Options): Promise<User>;
-  create(data: RequirementsOf<User, RequiredProps>, options?: Options) {
+  create(data: RequirementsOf<User, RequiredProps>, options: Options<User>): Promise<User>;
+  create(data: RequirementsOf<User, RequiredProps>, options?: Options<User>) {
     return super
       .fetch<User>({ url: this.apiPath, data, method: 'POST' })
       .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
   }
 
   get(id: number): Promise<User>;
-  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<User, any>>;
-  get(id: number, options: Options): Promise<User>;
-  get(id: number, options?: Options) {
+  get(id: number, options: { rawResponse: true } & Options<User>): Promise<AxiosResponse<User, any>>;
+  get(id: number, options: Options<User>): Promise<User>;
+  get(id: number, options?: Options<User>) {
     return super
-      .fetch<User>({ url: `${this.apiPath}/${id}` }, options)
+      .fetch({ url: `${this.apiPath}/${id}` }, options)
       .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
   }
 
-  async *list(query: UsersQueryParams, options?: Options) {
+  async *list(query: UsersQueryParams, options?: Options<User>) {
     for await (const res of super.iterator<User>({ url: this.apiPath, params: query }, options)) {
       yield res;
     }
   }
 
-  listAll(query: UsersQueryParams, options?: Options): Promise<User[]>;
-  async listAll(query: UsersQueryParams, options?: Options) {
+  listAll(query: UsersQueryParams, options?: Options<User>): Promise<User[]>;
+  async listAll(query: UsersQueryParams, options?: Options<User>) {
     const users = [] as User[];
     for await (const user of this.list(query, options)) {
       users.push(user);
@@ -45,14 +45,18 @@ export class UsersService extends Service {
     return users;
   }
 
-  listByPage(query: UsersQueryParams, options?: Options) {
+  listByPage(query: UsersQueryParams, options?: Options<User>) {
     return super.iterator<User>({ url: this.apiPath, params: query }, options).byPage();
   }
 
   update(id: number, data: Partial<User>): Promise<User>;
-  update(id: number, data: Partial<User>, options: { rawResponse: true } & Options): Promise<AxiosResponse<User, any>>;
-  update(id: number, data: Partial<User>, options: Options): Promise<User>;
-  update(id: number, data: Partial<User>, options?: Options) {
+  update(
+    id: number,
+    data: Partial<User>,
+    options: { rawResponse: true } & Options<User>,
+  ): Promise<AxiosResponse<User, any>>;
+  update(id: number, data: Partial<User>, options: Options<User>): Promise<User>;
+  update(id: number, data: Partial<User>, options?: Options<User>) {
     return super
       .fetch<User>({
         url: `${this.apiPath}/${id}`,
@@ -63,9 +67,9 @@ export class UsersService extends Service {
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<any, any>>;
-  delete(id: number, options: Options): Promise<number>;
-  delete(id: number, options?: Options) {
+  delete(id: number, options: { rawResponse: true } & Options<User>): Promise<AxiosResponse<any, any>>;
+  delete(id: number, options: Options<User>): Promise<number>;
+  delete(id: number, options?: Options<User>) {
     return super
       .fetch<User>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
       .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -48,7 +48,7 @@ export class UsersService extends Service<User> {
   listAll(query: UsersQueryParams): Promise<User[]>;
   listAll<F extends keyof User>(
     query: UsersQueryParams,
-    options: { fields: F[] } & OptionsExtended<User[]>,
+    options: { fields: F[] } & OptionsExtended<User>,
   ): Promise<Pick<User, F>[]>;
   listAll(query: UsersQueryParams, options?: OptionsExtended<User>): Promise<User[]>;
   async listAll(query: UsersQueryParams, options?: OptionsExtended<User>) {
@@ -62,7 +62,7 @@ export class UsersService extends Service<User> {
   listByPage(query: UsersQueryParams): AsyncGenerator<AxiosResponse<User[]>>;
   listByPage<F extends keyof User>(
     query: UsersQueryParams,
-    options: { fields: F[] } & OptionsExtended<User[]>,
+    options: { fields: F[] } & OptionsExtended<User>,
   ): AsyncGenerator<AxiosResponse<Pick<User, F>[]>>;
   listByPage(query: UsersQueryParams, options?: OptionsExtended<User>): AsyncGenerator<AxiosResponse<User[]>>;
   listByPage(query: UsersQueryParams, options?: OptionsExtended<User>) {

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { User } from '../interfaces/index.js';
-import { Service, Options, RequirementsOf } from './index.js';
+import { Service, Options, RequirementsOf, OptionsExtended } from './index.js';
 
 import { UsersQueryParams } from '../interfaces/query-params/users-query-params.interface.js';
 
@@ -12,41 +12,46 @@ export class UsersService extends Service<User> {
   create(data: RequirementsOf<User, RequiredProps>): Promise<User>;
   create(
     data: RequirementsOf<User, RequiredProps>,
-    options: { rawResponse: true } & Options<User>,
-  ): Promise<AxiosResponse<User, any>>;
-  create(data: RequirementsOf<User, RequiredProps>, options: Options<User>): Promise<User>;
-  create(data: RequirementsOf<User, RequiredProps>, options?: Options<User>) {
+    options: { rawResponse: true } & Options,
+  ): Promise<AxiosResponse<User>>;
+  create(data: RequirementsOf<User, RequiredProps>, options: Options): Promise<User>;
+  create(data: RequirementsOf<User, RequiredProps>, options?: Options) {
     return super
-      .fetch({ url: this.apiPath, data, method: 'POST' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<User>({ url: this.apiPath, data, method: 'POST' }, options)
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   get(id: number): Promise<User>;
-  get(
-    id: number,
-    options: { expand: string[]; fields: string[]; rawResponse: true } & Options<User>,
-  ): Promise<AxiosResponse<Partial<User>>>;
   get<F extends keyof User>(
     id: number,
-    options: { fields: F[]; rawResponse: true } & Options<User>,
+    options: { fields: F[]; rawResponse: true } & OptionsExtended<User>,
   ): Promise<AxiosResponse<Pick<User, F>>>;
-  get<F extends keyof User>(id: number, options: { fields: F[] } & Options<User>): Promise<Pick<User, F>>;
-  get(id: number, options: { rawResponse: true } & Options<User>): Promise<AxiosResponse<User>>;
-  get(id: number, options?: Options<User>): Promise<User>;
-  async get(id: number, options?: Options<User>) {
+  get<F extends keyof User>(id: number, options: { fields: F[] } & OptionsExtended<User>): Promise<Pick<User, F>>;
+  get(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<User>>;
+  get(id: number, options?: OptionsExtended<User>): Promise<User>;
+  get(id: number, options?: OptionsExtended<User>) {
     return super
       .fetch<User>({ url: `${this.apiPath}/${id}` }, options)
       .then((res) => (options?.rawResponse ? res : res.data));
   }
 
-  async *list(query: UsersQueryParams, options?: Options<User>) {
-    for await (const res of super.iterator<User>({ url: this.apiPath, params: query }, options)) {
-      yield res;
-    }
+  list(query: UsersQueryParams): AsyncGenerator<User>;
+  list<F extends keyof User>(
+    query: UsersQueryParams,
+    options: { fields: F[] } & OptionsExtended<User>,
+  ): AsyncGenerator<Pick<User, F>>;
+  list(query: UsersQueryParams, options?: OptionsExtended<User>): AsyncGenerator<User>;
+  async *list(query: UsersQueryParams, options?: OptionsExtended<User>) {
+    yield* super.iterator({ url: this.apiPath, params: query }, options);
   }
 
-  listAll(query: UsersQueryParams, options?: Options<User>): Promise<User[]>;
-  async listAll(query: UsersQueryParams, options?: Options<User>) {
+  listAll(query: UsersQueryParams): Promise<User[]>;
+  listAll<F extends keyof User>(
+    query: UsersQueryParams,
+    options: { fields: F[] } & OptionsExtended<User[]>,
+  ): Promise<Pick<User, F>[]>;
+  listAll(query: UsersQueryParams, options?: OptionsExtended<User>): Promise<User[]>;
+  async listAll(query: UsersQueryParams, options?: OptionsExtended<User>) {
     const users = [] as User[];
     for await (const user of this.list(query, options)) {
       users.push(user);
@@ -54,33 +59,38 @@ export class UsersService extends Service<User> {
     return users;
   }
 
-  listByPage(query: UsersQueryParams, options?: Options<User>) {
-    return super.iterator<User>({ url: this.apiPath, params: query }, options).byPage();
+  listByPage(query: UsersQueryParams): AsyncGenerator<AxiosResponse<User[]>>;
+  listByPage<F extends keyof User>(
+    query: UsersQueryParams,
+    options: { fields: F[] } & OptionsExtended<User[]>,
+  ): AsyncGenerator<AxiosResponse<Pick<User, F>[]>>;
+  listByPage(query: UsersQueryParams, options?: OptionsExtended<User>): AsyncGenerator<AxiosResponse<User[]>>;
+  listByPage(query: UsersQueryParams, options?: OptionsExtended<User>) {
+    return super.iterator({ url: this.apiPath, params: query }, options).byPage();
   }
 
   update(id: number, data: Partial<User>): Promise<User>;
-  update(
-    id: number,
-    data: Partial<User>,
-    options: { rawResponse: true } & Options<User>,
-  ): Promise<AxiosResponse<User, any>>;
-  update(id: number, data: Partial<User>, options: Options<User>): Promise<User>;
-  update(id: number, data: Partial<User>, options?: Options<User>) {
+  update(id: number, data: Partial<User>, options: { rawResponse: true } & Options): Promise<AxiosResponse<User, any>>;
+  update(id: number, data: Partial<User>, options: Options): Promise<User>;
+  update(id: number, data: Partial<User>, options?: Options) {
     return super
-      .fetch({
-        url: `${this.apiPath}/${id}`,
-        data,
-        method: 'POST',
-      })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<User>(
+        {
+          url: `${this.apiPath}/${id}`,
+          data,
+          method: 'POST',
+        },
+        options,
+      )
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options<User>): Promise<AxiosResponse<any, any>>;
-  delete(id: number, options: Options<User>): Promise<number>;
-  delete(id: number, options?: Options<User>) {
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  delete(id: number, options: Options): Promise<number>;
+  delete(id: number, options?: Options) {
     return super
-      .fetch({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
+      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -17,17 +17,22 @@ export class UsersService extends Service<User> {
   create(data: RequirementsOf<User, RequiredProps>, options: Options<User>): Promise<User>;
   create(data: RequirementsOf<User, RequiredProps>, options?: Options<User>) {
     return super
-      .fetch<User>({ url: this.apiPath, data, method: 'POST' })
+      .fetch({ url: this.apiPath, data, method: 'POST' })
       .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
   }
 
   get(id: number): Promise<User>;
-  get(id: number, options: { rawResponse: true } & Options<User>): Promise<AxiosResponse<User, any>>;
-  get(id: number, options: Options<User>): Promise<User>;
-  get(id: number, options?: Options<User>) {
+  get<F extends keyof User>(
+    id: number,
+    options: { fields: F[]; rawResponse: true } & Options<User>,
+  ): Promise<AxiosResponse<Pick<User, F>>>;
+  get<F extends keyof User>(id: number, options: { fields: F[] } & Options<User>): Promise<Pick<User, F>>;
+  get(id: number, options: { rawResponse: true } & Options<User>): Promise<AxiosResponse<User>>;
+  get(id: number, options?: Options<User>): Promise<User>;
+  async get(id: number, options?: Options<User>) {
     return super
-      .fetch({ url: `${this.apiPath}/${id}` }, options)
-      .then((res) => Promise.resolve(options?.rawResponse ? res : res.data));
+      .fetch<User>({ url: `${this.apiPath}/${id}` }, options)
+      .then((res) => (options?.rawResponse ? res : res.data));
   }
 
   async *list(query: UsersQueryParams, options?: Options<User>) {
@@ -58,7 +63,7 @@ export class UsersService extends Service<User> {
   update(id: number, data: Partial<User>, options: Options<User>): Promise<User>;
   update(id: number, data: Partial<User>, options?: Options<User>) {
     return super
-      .fetch<User>({
+      .fetch({
         url: `${this.apiPath}/${id}`,
         data,
         method: 'POST',
@@ -71,7 +76,7 @@ export class UsersService extends Service<User> {
   delete(id: number, options: Options<User>): Promise<number>;
   delete(id: number, options?: Options<User>) {
     return super
-      .fetch<User>({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
+      .fetch({ url: `${this.apiPath}/${id}`, method: 'DELETE' })
       .then((res) => Promise.resolve(options?.rawResponse ? res : res.status));
   }
 }

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -22,6 +22,10 @@ export class UsersService extends Service<User> {
   }
 
   get(id: number): Promise<User>;
+  get(
+    id: number,
+    options: { expand: string[]; fields: string[]; rawResponse: true } & Options<User>,
+  ): Promise<AxiosResponse<Partial<User>>>;
   get<F extends keyof User>(
     id: number,
     options: { fields: F[]; rawResponse: true } & Options<User>,

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -86,11 +86,11 @@ export class UsersService extends Service<User> {
   }
 
   delete(id: number): Promise<number>;
-  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<number>>;
+  delete(id: number, options: { rawResponse: true } & Options): Promise<AxiosResponse<void>>;
   delete(id: number, options: Options): Promise<number>;
   delete(id: number, options?: Options) {
     return super
-      .fetch<number>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
+      .fetch<void>({ url: `${this.apiPath}/${id}`, method: 'DELETE' }, options)
       .then((res) => (options?.rawResponse ? res : res.status));
   }
 }

--- a/todo.md
+++ b/todo.md
@@ -1,6 +1,0 @@
-# TODO
-
-- [x] Find way to make `Options["fields"]` strict
-  - [x] Find way to make `Options["fields"]` strict but support `expand` usage
-  - [ ] Ensure all service usage of `Options["fields"]` is strict
-- [x] Find way to make usage of methods using `Options["fields"]` return correct types

--- a/todo.md
+++ b/todo.md
@@ -1,6 +1,6 @@
 # TODO
 
 - [x] Find way to make `Options["fields"]` strict
-  - [ ] Find way to make `Options["fields"]` strict but support `expand` usage
+  - [x] Find way to make `Options["fields"]` strict but support `expand` usage
   - [ ] Ensure all service usage of `Options["fields"]` is strict
 - [x] Find way to make usage of methods using `Options["fields"]` return correct types

--- a/todo.md
+++ b/todo.md
@@ -3,4 +3,4 @@
 - [x] Find way to make `Options["fields"]` strict
   - [ ] Find way to make `Options["fields"]` strict but support `expand` usage
   - [ ] Ensure all service usage of `Options["fields"]` is strict
-- [ ] Find way to make usage of methods using `Options["fields"]` return correct types
+- [x] Find way to make usage of methods using `Options["fields"]` return correct types

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,6 @@
+# TODO
+
+- [x] Find way to make `Options["fields"]` strict
+  - [ ] Find way to make `Options["fields"]` strict but support `expand` usage
+  - [ ] Ensure all service usage of `Options["fields"]` is strict
+- [ ] Find way to make usage of methods using `Options["fields"]` return correct types


### PR DESCRIPTION
Adds proper type support for the `fields` option and the option is now only available on endpoints that support it.

Previously using fields would give the wrong types back and was error prone:
```ts
// Requesting a user with `fields` - TS would compile the following:
const user = await client.users.get(1, {fields: ["name", "bad-property"]})

// And `user` at this point would have the type `User` meaning this would compile even though `id` is actually undefined
console.log(user.id) // "undefined"
```

So not only was `fields` prone to typo bugs but the type returned would be wrong.

With this change both of these issues are solved:
```ts
// Only valid properties are now supported
const user = await client.users.get(1, {fields: ["name", "bad-property"]}) // -> error `"bad-property"` is not a valid property on type `User`

// Types returned reflect the properties requested
const user = await client.users.get(1, {fields: ["name", "dob"]} // `user` will have type `Pick<User, "name" | "dob">
console.log(user.id) // error -> `"id"` doesn't exist on type `Pick<User, "name" | "dob">`
```

Additionally `fields` is now only applied to endpoints that support it and only for `get` and `list` methods better matching the API
```ts
// allowed:
const users = await client.users.listAll(1, {fields: ["name"]})

// disallowed as `fields` isn't supported on this endpoint
const toilAccrual = await client.toilAccruals.get(1, {fields: ["id"]}) // -> error `"fields"` is not a valid option
```
---
## Other changes
- fixed: options not being supplied in many methods (which would fail silently and potentially give the wrong type)
- refactor: removed unnecessary `Promise.resolve` methods used within promises
- refactor: removed unused internal query params interface
- fixed: all `list` method `query` params that can be optional are now optional