### PR TITLE
fix: fix types for clock in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.11.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=16.10.0"

--- a/src/interfaces/users-clocked-in.interface.ts
+++ b/src/interfaces/users-clocked-in.interface.ts
@@ -1,4 +1,4 @@
-import { Shift, TerminalLocation } from '../interfaces/index.js';
+import { Shift, TerminalLocation, UserBreak } from '../interfaces/index.js';
 
 export interface UserClockedIn {
   user: number;
@@ -11,4 +11,5 @@ export interface UserClockedIn {
   in_location: TerminalLocation;
   in_device: string | null;
   in_terminal: number | null;
+  breaks_clocked: UserBreak[];
 }

--- a/src/services/users-clock-in.service.ts
+++ b/src/services/users-clock-in.service.ts
@@ -4,11 +4,11 @@ import { Service, Options, RequirementsOf, OptionsExtended } from './index.js';
 
 interface UserClockIn {
   method: string;
-  shift?: number;
-  terminal: number;
+  shift: number;
+  terminal?: number;
   user: number;
   photo?: string;
-  location: TerminalLocation;
+  location?: TerminalLocation;
 }
 
 interface UserClockOut extends Omit<UserClockIn, 'user' | 'shift'> {}
@@ -16,9 +16,9 @@ interface UserClockOut extends Omit<UserClockIn, 'user' | 'shift'> {}
 interface UserBreakRequest {
   method: string;
   action: string;
-  terminal?: number;
+  terminal: number;
   photo?: string;
-  location?: TerminalLocation;
+  location: TerminalLocation;
 }
 
 type RequiredPropsClockIn = 'method';

--- a/src/services/users-clock-in.service.ts
+++ b/src/services/users-clock-in.service.ts
@@ -4,7 +4,7 @@ import { Service, Options, RequirementsOf, OptionsExtended } from './index.js';
 
 interface UserClockIn {
   method: string;
-  shift: number;
+  shift?: number;
   terminal: number;
   user: number;
   photo?: string;
@@ -16,9 +16,9 @@ interface UserClockOut extends Omit<UserClockIn, 'user' | 'shift'> {}
 interface UserBreakRequest {
   method: string;
   action: string;
-  terminal: number;
+  terminal?: number;
   photo?: string;
-  location: TerminalLocation;
+  location?: TerminalLocation;
 }
 
 type RequiredPropsClockIn = 'method';


### PR DESCRIPTION
Add missing breaks_clocked to the UserClockedIn response

Makes some of the UserClockIn request optional. You don't need always need a shift ID because you can clock in without a shift. You don't need `terminal` if `method` is "mobile", and you don't need `location` if `method` is "terminal".