### PR TITLE
misc/interceptors - feat: add support for supplying custom interceptors for requests and responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.11.7",
-        "axios": "^1.4.0",
-        "axios-retry": "^3.6.0"
+        "axios": "^1.6.5",
+        "axios-retry": "^4.0.0"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.2.1",
@@ -23,8 +23,8 @@
         "eslint-config-airbnb-typescript": "^17.1.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.28.0",
-        "prettier": "~3.0.1",
-        "typescript": "^5.1.6"
+        "prettier": "~3.2.2",
+        "typescript": "^5.3.3"
       },
       "engines": {
         "node": ">=16.10.0"
@@ -43,6 +43,7 @@
       "version": "7.22.10",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
       "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -639,22 +640,24 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios-retry": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.6.0.tgz",
-      "integrity": "sha512-jtH4qWTKZ2a17dH6tjq52Y1ssNV0lKge6/Z9Lw67s9Wt01nGTg4hg7/LJBGYfDci44NTANJQlCPHPOT/TSFm9w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.0.0.tgz",
+      "integrity": "sha512-F6P4HVGITD/v4z9Lw2mIA24IabTajvpDZmKa6zq/gGwn57wN5j1P3uWrAV0+diqnW6kTM2fTqmWNfgYWGmMuiA==",
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
         "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
       }
     },
     "node_modules/axobject-query": {
@@ -1656,9 +1659,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -2749,9 +2752,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
-      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.2.tgz",
+      "integrity": "sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -2819,7 +2822,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+      "dev": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
@@ -3325,9 +3329,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3500,6 +3504,7 @@
       "version": "7.22.10",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
       "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
@@ -3897,21 +3902,20 @@
       "peer": true
     },
     "axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
       "requires": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
     },
     "axios-retry": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.6.0.tgz",
-      "integrity": "sha512-jtH4qWTKZ2a17dH6tjq52Y1ssNV0lKge6/Z9Lw67s9Wt01nGTg4hg7/LJBGYfDci44NTANJQlCPHPOT/TSFm9w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.0.0.tgz",
+      "integrity": "sha512-F6P4HVGITD/v4z9Lw2mIA24IabTajvpDZmKa6zq/gGwn57wN5j1P3uWrAV0+diqnW6kTM2fTqmWNfgYWGmMuiA==",
       "requires": {
-        "@babel/runtime": "^7.15.4",
         "is-retry-allowed": "^2.2.0"
       }
     },
@@ -4677,9 +4681,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -5453,9 +5457,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
-      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.2.tgz",
+      "integrity": "sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==",
       "dev": true
     },
     "prop-types": {
@@ -5497,7 +5501,8 @@
     "regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+      "dev": true
     },
     "regexp.prototype.flags": {
       "version": "1.5.0",
@@ -5856,9 +5861,9 @@
       }
     },
     "typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "eslint-config-airbnb-typescript": "^17.1.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.28.0",
-    "prettier": "~3.0.1",
-    "typescript": "^5.1.6"
+    "prettier": "~3.2.2",
+    "typescript": "^5.3.3"
   },
   "dependencies": {
     "@types/node": "^16.11.7",
-    "axios": "^1.4.0",
-    "axios-retry": "^3.6.0"
+    "axios": "^1.6.5",
+    "axios-retry": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=16.10.0"

--- a/src/interfaces/sdk-config.interface.ts
+++ b/src/interfaces/sdk-config.interface.ts
@@ -1,10 +1,30 @@
+import { AxiosInterceptorManager, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import { RetryOptions, RetryStrategy } from '../services/service.js';
+
+type RequestInterceptor = Parameters<AxiosInterceptorManager<InternalAxiosRequestConfig>['use']>;
+type ResponseInterceptor = Parameters<AxiosInterceptorManager<AxiosResponse>['use']>;
 
 export interface SDKBase {
   baseUri?: string;
   accountId?: number;
   userId?: number;
   retry?: false | `${RetryStrategy}` | RetryOptions;
+  interceptors?: {
+    request?: (
+      | RequestInterceptor[0]
+      | {
+          success?: RequestInterceptor[0];
+          error?: RequestInterceptor[1];
+        }
+    )[];
+    response?: (
+      | ResponseInterceptor[0]
+      | {
+          success?: ResponseInterceptor[0];
+          error?: ResponseInterceptor[1];
+        }
+    )[];
+  };
   [key: string]: unknown;
 }
 

--- a/src/rotacloud.ts
+++ b/src/rotacloud.ts
@@ -35,7 +35,7 @@ const DEFAULT_CONFIG: Partial<SDKBase> = {
   retry: RetryStrategy.Exponential,
 };
 
-function parseClientError(error: AxiosError): SDKError | unknown {
+function parseClientError(error: AxiosError): SDKError {
   const axiosErrorLocation = error.response || error.request;
   const apiErrorMessage = axiosErrorLocation.data?.error;
   return new SDKError({

--- a/src/rotacloud.ts
+++ b/src/rotacloud.ts
@@ -90,7 +90,7 @@ export class RotaCloud {
   set config(configVal: SDKConfig) {
     RotaCloud.config = configVal;
     this.client.interceptors.request.clear();
-    this.client.interceptors.request.clear();
+    this.client.interceptors.response.clear();
     this.client.interceptors.response.use(
       (response) => response,
       (error: unknown) => {

--- a/src/rotacloud.ts
+++ b/src/rotacloud.ts
@@ -1,3 +1,4 @@
+import axios, { AxiosError, isAxiosError } from 'axios';
 import {
   AccountsService,
   AttendanceService,
@@ -27,41 +28,53 @@ import {
 } from './services/index.js';
 import { SDKBase, SDKConfig } from './interfaces/index.js';
 import { PinsService } from './services/pins.service.js';
+import { SDKError } from './models/index.js';
 
 const DEFAULT_CONFIG: Partial<SDKBase> = {
   baseUri: 'https://api.rotacloud.com/v1',
   retry: RetryStrategy.Exponential,
 };
 
-export class RotaCloud {
-  public static config: SDKConfig;
+function parseClientError(error: AxiosError): SDKError | unknown {
+  const axiosErrorLocation = error.response || error.request;
+  const apiErrorMessage = axiosErrorLocation.data?.error;
+  return new SDKError({
+    code: axiosErrorLocation.status,
+    message: apiErrorMessage || error.message,
+    data: axiosErrorLocation.data,
+  });
+}
 
-  public defaultAPIURI = DEFAULT_CONFIG.baseUri;
-  public accounts = new AccountsService();
-  public attendance = new AttendanceService();
-  public auth = new AuthService();
-  public availability = new AvailabilityService();
-  public dailyBudgets = new DailyBudgetsService();
-  public dailyRevenue = new DailyRevenueService();
-  public dayNotes = new DayNotesService();
-  public daysOff = new DaysOffService();
-  public group = new GroupsService();
-  public leaveEmbargoes = new LeaveEmbargoesService();
-  public leaveRequests = new LeaveRequestService();
-  public leaveTypes = new LeaveTypesService();
-  public leave = new LeaveService();
-  public locations = new LocationsService();
-  public pins = new PinsService();
-  public roles = new RolesService();
-  public settings = new SettingsService();
-  public shifts = new ShiftsService();
-  public terminals = new TerminalsService();
-  public terminalsActive = new TerminalsActiveService();
-  public timeZone = new TimeZoneService();
-  public toilAccruals = new ToilAccrualsService();
-  public toilAllowance = new ToilAllowanceService();
-  public usersClockInService = new UsersClockInService();
-  public users = new UsersService();
+export class RotaCloud {
+  static config: SDKConfig;
+  private client = axios.create();
+
+  defaultAPIURI = DEFAULT_CONFIG.baseUri;
+  accounts = new AccountsService(this.client);
+  attendance = new AttendanceService(this.client);
+  auth = new AuthService(this.client);
+  availability = new AvailabilityService(this.client);
+  dailyBudgets = new DailyBudgetsService(this.client);
+  dailyRevenue = new DailyRevenueService(this.client);
+  dayNotes = new DayNotesService(this.client);
+  daysOff = new DaysOffService(this.client);
+  group = new GroupsService(this.client);
+  leaveEmbargoes = new LeaveEmbargoesService(this.client);
+  leaveRequests = new LeaveRequestService(this.client);
+  leaveTypes = new LeaveTypesService(this.client);
+  leave = new LeaveService(this.client);
+  locations = new LocationsService(this.client);
+  pins = new PinsService(this.client);
+  roles = new RolesService(this.client);
+  settings = new SettingsService(this.client);
+  shifts = new ShiftsService(this.client);
+  terminals = new TerminalsService(this.client);
+  terminalsActive = new TerminalsActiveService(this.client);
+  timeZone = new TimeZoneService(this.client);
+  toilAccruals = new ToilAccrualsService(this.client);
+  toilAllowance = new ToilAllowanceService(this.client);
+  usersClockInService = new UsersClockInService(this.client);
+  users = new UsersService(this.client);
 
   constructor(config: SDKConfig) {
     this.config = {
@@ -76,6 +89,32 @@ export class RotaCloud {
 
   set config(configVal: SDKConfig) {
     RotaCloud.config = configVal;
+    this.client.interceptors.request.clear();
+    this.client.interceptors.request.clear();
+    this.client.interceptors.response.use(
+      (response) => response,
+      (error: unknown) => {
+        let parsedError = error;
+        if (isAxiosError(error)) {
+          parsedError = parseClientError(error);
+        }
+        return Promise.reject(parsedError);
+      },
+    );
+    for (const requestInterceptor of this.config.interceptors?.request ?? []) {
+      const callbacks =
+        typeof requestInterceptor === 'function'
+          ? ([requestInterceptor] as const)
+          : ([requestInterceptor?.success, requestInterceptor?.error] as const);
+      this.client.interceptors.request.use(...callbacks);
+    }
+    for (const responseInterceptor of this.config.interceptors?.response ?? []) {
+      const callbacks =
+        typeof responseInterceptor === 'function'
+          ? ([responseInterceptor] as const)
+          : ([responseInterceptor?.success, responseInterceptor?.error] as const);
+      this.client.interceptors.response.use(...callbacks);
+    }
   }
 }
 

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -1,8 +1,7 @@
-import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import axiosRetry from 'axios-retry';
 import { RotaCloud } from '../rotacloud.js';
 import { Version } from '../version.js';
-import { SDKErrorConfig, SDKError } from '../models/SDKError.model.js';
 
 export type RequirementsOf<T, K extends keyof T> = Required<Pick<T, K>> & Partial<T>;
 
@@ -57,33 +56,7 @@ type ParameterPrimitive = string | boolean | number | null | symbol;
 type ParameterValue = ParameterPrimitive | ParameterPrimitive[] | undefined;
 
 export abstract class Service<ApiResponse = any> {
-  protected client: AxiosInstance = this.initialiseAxios();
-
-  private initialiseAxios(): AxiosInstance {
-    const client = axios.create();
-    client.interceptors.response.use(
-      (response) => response,
-      (error) => {
-        const parsedError = this.parseClientError(error);
-
-        return Promise.reject(parsedError);
-      },
-    );
-    return client;
-  }
-
-  private parseClientError(error: unknown | AxiosError): SDKError | unknown {
-    if (!axios.isAxiosError(error)) return error;
-    const axiosErrorLocation = error.response || error.request;
-    const apiErrorMessage = axiosErrorLocation.data?.error;
-    const sdkErrorParams: SDKErrorConfig = {
-      code: axiosErrorLocation.status,
-      message: apiErrorMessage || error.message,
-      data: axiosErrorLocation.data,
-    };
-
-    return new SDKError(sdkErrorParams);
-  }
+  constructor(protected client: AxiosInstance) {}
 
   private isLeaveRequest(endpoint?: string): boolean {
     return endpoint === '/leave_requests';


### PR DESCRIPTION
Adds the ability to supply interceptors (currently based around axios' implementation) to the SDK config.

Example:
```ts
const client = new RotaCloud({
	apiKey: '...',
	accountId: 12345,
	// Optional property with both `request` and `response` also being optional
	interceptors: {
		// Can supply as many as you like:
		request: [
			// Can supply a single callback method for handling successful requests
			(req) => {
				console.log('Request intercepted');
				return req;
			},
		],
		response: [
			// Or supply an object specifying either or both of the success and error handlers
			{
				success: (res) => {
					console.log("Response intercepted");
					return res;
				},
				error: (res) => {
					console.log("Handling error...");
					return res;
				}
		],
	},
});
```

As this is using axios interceptors under the hood the same types and implementation details apply: https://axios-http.com/docs/interceptors

Other parts to note:
- These interceptors can only be supplied via the config object
- Interceptors will be setup any time the config is changed
- Changing the config after creating a client will remove all previously set interceptors and replace them with the new specified interceptors (if there are any)
  - Meaning interceptors can be cleared by setting the client config to the same config just without the `interceptors` property specified or set to `undefined`