### PR TITLE
misc/retry-fix - fix: axios-retry configuration and isolate SDKConfig to SDK instances

### DIFF
--- a/src/interfaces/sdk-config.interface.ts
+++ b/src/interfaces/sdk-config.interface.ts
@@ -25,6 +25,7 @@ type RequestInterceptor = Parameters<AxiosInterceptorManager<InternalAxiosReques
 type ResponseInterceptor = Parameters<AxiosInterceptorManager<AxiosResponse>['use']>;
 
 export interface SDKBase {
+  logging: (...message: any[]) => void;
   baseUri?: string;
   accountId?: number;
   userId?: number;

--- a/src/interfaces/sdk-config.interface.ts
+++ b/src/interfaces/sdk-config.interface.ts
@@ -1,5 +1,25 @@
 import { AxiosInterceptorManager, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
-import { RetryOptions, RetryStrategy } from '../services/service.js';
+
+export enum RetryStrategy {
+  Exponential = 'expo',
+  Static = 'static',
+}
+
+export type RetryOptions =
+  | {
+      /** Use exponential back-off */
+      exponential?: false;
+      /** The maximum number of retries before erroring */
+      maxRetries: number;
+      /** Delay in milliseconds between retry attempts - not used in exponential back-off */
+      delay: number;
+    }
+  | {
+      /** Use exponential back-off */
+      exponential: true;
+      /** The maximum number of retries before erroring */
+      maxRetries: number;
+    };
 
 type RequestInterceptor = Parameters<AxiosInterceptorManager<InternalAxiosRequestConfig>['use']>;
 type ResponseInterceptor = Parameters<AxiosInterceptorManager<AxiosResponse>['use']>;

--- a/src/interfaces/sdk-config.interface.ts
+++ b/src/interfaces/sdk-config.interface.ts
@@ -25,7 +25,6 @@ type RequestInterceptor = Parameters<AxiosInterceptorManager<InternalAxiosReques
 type ResponseInterceptor = Parameters<AxiosInterceptorManager<AxiosResponse>['use']>;
 
 export interface SDKBase {
-  logging: (...message: any[]) => void;
   baseUri?: string;
   accountId?: number;
   userId?: number;

--- a/src/rotacloud.ts
+++ b/src/rotacloud.ts
@@ -61,49 +61,79 @@ function parseClientError(error: AxiosError): SDKError {
 }
 
 export class RotaCloud {
-  static config: SDKConfig;
   private client = axios.create();
+  private sdkConfig: SDKConfig;
+  private logging: (...message: any[]) => void;
 
   defaultAPIURI = DEFAULT_CONFIG.baseUri;
-  accounts = new AccountsService(this.client);
-  attendance = new AttendanceService(this.client);
-  auth = new AuthService(this.client);
-  availability = new AvailabilityService(this.client);
-  dailyBudgets = new DailyBudgetsService(this.client);
-  dailyRevenue = new DailyRevenueService(this.client);
-  dayNotes = new DayNotesService(this.client);
-  daysOff = new DaysOffService(this.client);
-  group = new GroupsService(this.client);
-  leaveEmbargoes = new LeaveEmbargoesService(this.client);
-  leaveRequests = new LeaveRequestService(this.client);
-  leaveTypes = new LeaveTypesService(this.client);
-  leave = new LeaveService(this.client);
-  locations = new LocationsService(this.client);
-  pins = new PinsService(this.client);
-  roles = new RolesService(this.client);
-  settings = new SettingsService(this.client);
-  shifts = new ShiftsService(this.client);
-  terminals = new TerminalsService(this.client);
-  terminalsActive = new TerminalsActiveService(this.client);
-  timeZone = new TimeZoneService(this.client);
-  toilAccruals = new ToilAccrualsService(this.client);
-  toilAllowance = new ToilAllowanceService(this.client);
-  usersClockInService = new UsersClockInService(this.client);
-  users = new UsersService(this.client);
+  accounts: AccountsService;
+  attendance: AttendanceService;
+  auth: AuthService;
+  availability: AvailabilityService;
+  dailyBudgets: DailyBudgetsService;
+  dailyRevenue: DailyRevenueService;
+  dayNotes: DayNotesService;
+  daysOff: DaysOffService;
+  group: GroupsService;
+  leaveEmbargoes: LeaveEmbargoesService;
+  leaveRequests: LeaveRequestService;
+  leaveTypes: LeaveTypesService;
+  leave: LeaveService;
+  locations: LocationsService;
+  pins: PinsService;
+  roles: RolesService;
+  settings: SettingsService;
+  shifts: ShiftsService;
+  terminals: TerminalsService;
+  terminalsActive: TerminalsActiveService;
+  timeZone: TimeZoneService;
+  toilAccruals: ToilAccrualsService;
+  toilAllowance: ToilAllowanceService;
+  usersClockInService: UsersClockInService;
+  users: UsersService;
 
   constructor(config: SDKConfig) {
-    this.config = {
+    const updatedConfig = {
       ...DEFAULT_CONFIG,
       ...config,
-    };
+    }
+
+    this.config = updatedConfig;
+
+    this.accounts = new AccountsService(this.client, updatedConfig);
+    this.attendance = new AttendanceService(this.client, updatedConfig);
+    this.auth = new AuthService(this.client, updatedConfig);
+    this.availability = new AvailabilityService(this.client, updatedConfig);
+    this.dailyBudgets = new DailyBudgetsService(this.client, updatedConfig);
+    this.dailyRevenue = new DailyRevenueService(this.client, updatedConfig);
+    this.dayNotes = new DayNotesService(this.client, updatedConfig);
+    this.daysOff = new DaysOffService(this.client, updatedConfig);
+    this.group = new GroupsService(this.client, updatedConfig);
+    this.leaveEmbargoes = new LeaveEmbargoesService(this.client, updatedConfig);
+    this.leaveRequests = new LeaveRequestService(this.client, updatedConfig);
+    this.leaveTypes = new LeaveTypesService(this.client, updatedConfig);
+    this.leave = new LeaveService(this.client, updatedConfig);
+    this.locations = new LocationsService(this.client, updatedConfig);
+    this.pins = new PinsService(this.client, updatedConfig);
+    this.roles = new RolesService(this.client, updatedConfig);
+    this.settings = new SettingsService(this.client, updatedConfig);
+    this.shifts = new ShiftsService(this.client, updatedConfig);
+    this.terminals = new TerminalsService(this.client, updatedConfig);
+    this.terminalsActive = new TerminalsActiveService(this.client, updatedConfig);
+    this.timeZone = new TimeZoneService(this.client, updatedConfig);
+    this.toilAccruals = new ToilAccrualsService(this.client, updatedConfig);
+    this.toilAllowance = new ToilAllowanceService(this.client, updatedConfig);
+    this.usersClockInService = new UsersClockInService(this.client, updatedConfig);
+    this.users = new UsersService(this.client, updatedConfig);
   }
 
   get config() {
-    return RotaCloud.config;
+    return this.sdkConfig;
   }
 
   set config(configVal: SDKConfig) {
-    RotaCloud.config = configVal;
+    this.logging(configVal);
+    this.sdkConfig = configVal;
     this.setupInterceptors(configVal.retry, configVal.interceptors);
   }
 

--- a/src/rotacloud.ts
+++ b/src/rotacloud.ts
@@ -63,7 +63,6 @@ function parseClientError(error: AxiosError): SDKError {
 export class RotaCloud {
   private client = axios.create();
   private sdkConfig: SDKConfig;
-  private logging: (...message: any[]) => void;
 
   defaultAPIURI = DEFAULT_CONFIG.baseUri;
   accounts: AccountsService;
@@ -93,38 +92,50 @@ export class RotaCloud {
   users: UsersService;
 
   constructor(config: SDKConfig) {
-    const updatedConfig = {
-      ...DEFAULT_CONFIG,
-      ...config,
+    this.config = this.createConfig(config);
+    const client = this;
+    const options = {
+      get config(): SDKConfig {
+        return client.config;
+      }
     }
 
-    this.config = updatedConfig;
+    this.accounts = new AccountsService(this.client, options);
+    this.attendance = new AttendanceService(this.client, options);
+    this.auth = new AuthService(this.client, options);
+    this.availability = new AvailabilityService(this.client, options);
+    this.dailyBudgets = new DailyBudgetsService(this.client, options);
+    this.dailyRevenue = new DailyRevenueService(this.client, options);
+    this.dayNotes = new DayNotesService(this.client, options);
+    this.daysOff = new DaysOffService(this.client, options);
+    this.group = new GroupsService(this.client, options);
+    this.leaveEmbargoes = new LeaveEmbargoesService(this.client, options);
+    this.leaveRequests = new LeaveRequestService(this.client, options);
+    this.leaveTypes = new LeaveTypesService(this.client, options);
+    this.leave = new LeaveService(this.client, options);
+    this.locations = new LocationsService(this.client, options);
+    this.pins = new PinsService(this.client, options);
+    this.roles = new RolesService(this.client, options);
+    this.settings = new SettingsService(this.client, options);
+    this.shifts = new ShiftsService(this.client, options);
+    this.terminals = new TerminalsService(this.client, options);
+    this.terminalsActive = new TerminalsActiveService(this.client, options);
+    this.timeZone = new TimeZoneService(this.client, options);
+    this.toilAccruals = new ToilAccrualsService(this.client, options);
+    this.toilAllowance = new ToilAllowanceService(this.client, options);
+    this.usersClockInService = new UsersClockInService(this.client, options);
+    this.users = new UsersService(this.client, options);
+  }
 
-    this.accounts = new AccountsService(this.client, updatedConfig);
-    this.attendance = new AttendanceService(this.client, updatedConfig);
-    this.auth = new AuthService(this.client, updatedConfig);
-    this.availability = new AvailabilityService(this.client, updatedConfig);
-    this.dailyBudgets = new DailyBudgetsService(this.client, updatedConfig);
-    this.dailyRevenue = new DailyRevenueService(this.client, updatedConfig);
-    this.dayNotes = new DayNotesService(this.client, updatedConfig);
-    this.daysOff = new DaysOffService(this.client, updatedConfig);
-    this.group = new GroupsService(this.client, updatedConfig);
-    this.leaveEmbargoes = new LeaveEmbargoesService(this.client, updatedConfig);
-    this.leaveRequests = new LeaveRequestService(this.client, updatedConfig);
-    this.leaveTypes = new LeaveTypesService(this.client, updatedConfig);
-    this.leave = new LeaveService(this.client, updatedConfig);
-    this.locations = new LocationsService(this.client, updatedConfig);
-    this.pins = new PinsService(this.client, updatedConfig);
-    this.roles = new RolesService(this.client, updatedConfig);
-    this.settings = new SettingsService(this.client, updatedConfig);
-    this.shifts = new ShiftsService(this.client, updatedConfig);
-    this.terminals = new TerminalsService(this.client, updatedConfig);
-    this.terminalsActive = new TerminalsActiveService(this.client, updatedConfig);
-    this.timeZone = new TimeZoneService(this.client, updatedConfig);
-    this.toilAccruals = new ToilAccrualsService(this.client, updatedConfig);
-    this.toilAllowance = new ToilAllowanceService(this.client, updatedConfig);
-    this.usersClockInService = new UsersClockInService(this.client, updatedConfig);
-    this.users = new UsersService(this.client, updatedConfig);
+  /**
+   * Overrides undefined config with the default config without removing getters in the object
+   */
+  private createConfig(config: SDKConfig): SDKConfig {
+    const keys = Object.keys(DEFAULT_CONFIG) as (keyof typeof DEFAULT_CONFIG)[];
+    for (const key of keys) {
+      config[key] ??= DEFAULT_CONFIG[key];
+    }
+    return config;
   }
 
   get config() {
@@ -132,7 +143,6 @@ export class RotaCloud {
   }
 
   set config(configVal: SDKConfig) {
-    this.logging(configVal);
     this.sdkConfig = configVal;
     this.setupInterceptors(configVal.retry, configVal.interceptors);
   }

--- a/src/rotacloud.ts
+++ b/src/rotacloud.ts
@@ -118,7 +118,7 @@ export class RotaCloud {
       axiosRetry(this.client, {
         retries: retryConfig.maxRetries,
         shouldResetTimeout: true,
-        retryCondition: (err: AxiosError) => isNetworkOrIdempotentRequestError(err) || err.response?.status === 429,
+        retryCondition: (err) => isNetworkOrIdempotentRequestError(err) || err.response?.status === 429,
         retryDelay: (retryCount) => {
           if (retryConfig.exponential) {
             return axiosRetry.exponentialDelay(retryCount);

--- a/src/services/accounts.service.ts
+++ b/src/services/accounts.service.ts
@@ -1,7 +1,7 @@
-import {AxiosResponse} from 'axios';
-import {OptionsExtended, Service} from './index.js';
+import { AxiosResponse } from 'axios';
+import { Service, Options, OptionsExtended } from './index.js';
 
-import {Account} from '../interfaces/index.js';
+import { Account } from '../interfaces/index.js';
 
 export class AccountsService extends Service<Account> {
   private apiPath = '/accounts';

--- a/src/services/accounts.service.ts
+++ b/src/services/accounts.service.ts
@@ -1,7 +1,7 @@
-import { AxiosResponse } from 'axios';
-import { Service, Options, OptionsExtended } from './index.js';
+import {AxiosResponse} from 'axios';
+import {OptionsExtended, Service} from './index.js';
 
-import { Account } from '../interfaces/index.js';
+import {Account} from '../interfaces/index.js';
 
 export class AccountsService extends Service<Account> {
   private apiPath = '/accounts';

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -21,6 +21,11 @@ type ParameterValue = ParameterPrimitive | ParameterPrimitive[] | undefined;
 export abstract class Service<ApiResponse = any> {
   constructor(
       protected client: AxiosInstance,
+      // opt to use options object here, so we could
+      // define the config property as a getter
+      // in RotaCloud class. With this change config in
+      // this class will always be up-to-date with
+      // RotaCloud client config
       protected readonly options: { config: SDKConfig }
   ) {}
 

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -1,6 +1,6 @@
-import {AxiosInstance, AxiosRequestConfig, AxiosResponse} from 'axios';
-import {SDKConfig} from '../rotacloud.js';
-import {Version} from '../version.js';
+import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { Version } from '../version.js';
+import { SDKConfig } from "../interfaces";
 
 export type RequirementsOf<T, K extends keyof T> = Required<Pick<T, K>> & Partial<T>;
 


### PR DESCRIPTION
Fixes a bug in which the retry configuration had stopped working; was being set for every request and wasn't attempting retries for `429` status codes.

With this change:
- axios-retry configuration is setup only when the SDK config has changed instead of every request made (including init of the `RotaCloud` class)
- axios-retry's underlying interceptor config is applied before all other interceptors
  - This includes the custom error interceptor so that axios-retry works with the `AxiosError` type
  - Previously this would be setup after all other interceptors
- axios-retry will now attempt to retry on `429` errors (`Too many requests`)
- SDKConfig is localized in each client. Previously all clients share the same SDKConfig but that limits us to only 1 baseURI. With this change we can now use custom baseURI or config for that matter on each service. ex. api.rotacloud-staging.com/v2 baseURI is now possible to use without tampering other clients baseURI