### PR TITLE
story/RWA-1563 - Update dailyRevenue to support null values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "1.4.1",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.11.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=16.10.0"

--- a/src/interfaces/daily-revenue.interface.ts
+++ b/src/interfaces/daily-revenue.interface.ts
@@ -1,7 +1,7 @@
 export interface DailyRevenue {
   date: string;
   location: number;
-  labour_percentage: number;
-  revenue_target: number;
-  revenue_actual: number;
+  labour_percentage: number | null;
+  revenue_target: number | null;
+  revenue_actual: number | null;
 }


### PR DESCRIPTION
I've modified the `DailyRevenue` to support null type for `labour_percentage` , `revenue_target` and `revenue_actual.` 