### PR TITLE
feat: support for max results in list requests to replace `limit` option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "1.4.9",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "1.4.9",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^16.11.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "1.4.9",
+  "version": "1.5.0",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "engines": {
     "node": ">=16.10.0"


### PR DESCRIPTION
Adds a new option `maxResults` to the `Options` type with the intention of replacing and ultimately removing the `limit` parameter which has now been marked deprecated.

# Context
`limit` from an SDK callers point of view can be quite misleading and confusing.
Here is a scenario in which it might be used:

```ts
const client = new RotaCloud(...)
const results = await client.shifts.listAll(..., { limit: 10 })
console.log(results.length)
```

To someone reading above code without understanding how the SDK works under the hood I think they would expect the length of the results to be 10 at most however what actually happens is every shift is returned (that matches the query parameter) but fetched in pages of 10 results each making this a worse version of specifying no limit at all as if there were 100 shifts matching the query the above code would return all 100 but in 10 requests (10 results on each page) instead of 1 request returning all 100.

This PR adds a new option `maxResults` to replace `limit` as I believe this to be more intutive; serves the same purpose and puts us in a position to remove `limit` entirely as from an SDK callers point of view, I think this shouldn't be used or available. See the example below:

```ts
const client = new RotaCloud(...)
const results = await client.shifts.listAll(..., { maxResults: 10 }) // Pages will be requested in batches of 10 the same as `limit`
console.log(results.length) // Guarenteed to be no more than 10
```

If the `maxResults` is specified to a number greater than the max page size a particular endpoint allows then more than one page will be fetched automatically as before using the maximum allowed page sized specified by the backend but as soon as the `maxResults` has been reached; pagination will stop