### PR TITLE
feat/v2-webapp-compat - feat: add missing functionality; improved docs and web platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,38 @@
 
 ## Getting started
 
-To use this SDK you'll need to `npm install rotacloud`. This will ensure you're ready to start working with the SDK in your project.
+To use this SDK you'll need to `npm install rotacloud`. This will ensure you're ready
+to start working with the SDK in your project.
 
 ## Contributing
 
-Please ensure you perform the `npm run version:bump` command before commiting and pushing your changes to the remote branch.
+Please ensure you perform the `npm run version:bump` command before commiting and
+pushing your changes to the remote branch.
 
 ## Configuration
 
-Configuration is simple, just import the core RotaCloud SDK and supply your API key as necessary.
+Configuration is simple, import the `createRotaCloudClient` function from the SDK
+and supply your API key:
 
 ```typescript
-import { RotaCloud } from 'rotacloud';
+import { createRotaCloudClient } from 'rotacloud';
 
-const rc = new RotaCloud({
+const client = createRotaCloudClient({
   apiKey: 'YOUR_API_KEY',
 });
 ```
 
 ## Auto paging
 
-Our SDK support auto pagination as a way for developers to quickly consume list based endpoints. You will find a `list()` method on most services within the SDK which can be consumed using `for await of`. **Please ensure you are catching errors in your implementation.**
+Our SDK supports auto pagination as a way for developers to quickly consume list based endpoints.
+You will find a `list()` method on most services within the SDK which can be consumed using
+`for await of`. **Please ensure you are catching errors in your implementation.**
 
 ```typescript
+const client = createRotaCloudClient({...})
+
 try {
-  for await (const user of rc.users.list()) {
+  for await (const user of client.user.list({})) {
     console.log(user);
   }
 } catch (e) {
@@ -36,25 +43,28 @@ try {
 
 ## Retry Policies
 
-Our SDK supports both basic and customisable retry polices. Both can be easily configured in the SDKConfig object at time of instantiation. Both exponential and static value based back offs are supported.
+Our SDK supports both basic and customisable retry polices.
+Both can be easily configured in the SDKConfig object at time of instantiation.
+Both exponential and static value based back offs are supported.
 
 Only idempotent requests will be retried.
 
 ```typescript
-import { RotaCloud } from 'rotacloud';
+import { createRotaCloudClient } from 'rotacloud';
 
-const rc = new RotaCloud({
+const client = createRotaCloudClient({
   apiKey: 'YOUR_API_KEY',
   retry: 'expo' | 'static',
 });
 ```
 
-If more granular control is required of the internal retry policy values, an object can be passed through the `retry` field.
+If more granular control is required of the internal retry policy values, an object
+of retry configuration can be passed through to the `retry` field instead.
 
 ```typescript
-import { RotaCloud } from 'rotacloud';
+import { createRotaCloudClient } from 'rotacloud';
 
-const rc = new RotaCloud({
+const client = createRotaCloudClient({
   apiKey: 'YOUR_API_KEY',
   retry: { delay: 2000, exponential: false, maxRetries: 10 },
 });

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You will find a `list()` method on most services within the SDK which can be con
 const client = createRotaCloudClient({...})
 
 try {
-  for await (const user of client.user.list({})) {
+  for await (const user of client.user.list()) {
     console.log(user);
   }
 } catch (e) {

--- a/src/client-builder.test.ts
+++ b/src/client-builder.test.ts
@@ -2,7 +2,7 @@ import { test, expect, describe, vi } from 'vitest';
 import { Axios } from 'axios';
 import { createSdkClient, DEFAULT_CONFIG } from './client-builder.js';
 import { SDKConfig } from './main.js';
-import { version } from '../package.json' assert { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 
 let mockAxiosClient: Axios;
 vi.mock(import('axios'), async (importOriginal) => {
@@ -68,7 +68,7 @@ describe('SDK client builder', () => {
         endpointVersion: 'v1',
         operations: ['get'],
         customOperations: {
-          customOp: () => {},
+          customOp: async () => {},
         },
       },
     });
@@ -112,7 +112,7 @@ describe('SDK client builder', () => {
     expect(mockAxiosClient.request).toHaveBeenCalledWith(
       expect.objectContaining({
         headers: expect.objectContaining({
-          'SDK-Version': version,
+          'SDK-Version': pkg.version,
         }),
       }),
     );

--- a/src/client-builder.ts
+++ b/src/client-builder.ts
@@ -75,9 +75,14 @@ export function createSdkClient<T extends Record<string, ServiceSpecification>>(
     let requestConfig = getBaseRequestConfig(clientConfig);
 
     const sdkClient = {
-      get fetch() {
-        return axiosClient.request;
-      },
+      fetch: (req) =>
+        axiosClient.request({
+          ...req,
+          headers: {
+            ...req.headers,
+            ...requestConfig.headers,
+          },
+        }),
       get config() {
         return clientConfig;
       },

--- a/src/client-builder.ts
+++ b/src/client-builder.ts
@@ -105,6 +105,10 @@ export function createSdkClient<T extends Record<string, ServiceSpecification>>(
         get request() {
           return requestConfig;
         },
+        // eslint-disable-next-line @typescript-eslint/no-loop-func
+        get sdkConfig() {
+          return clientConfig;
+        },
       });
     }
 

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -71,7 +71,7 @@ export interface EndpointEntityMap extends Record<EndpointVersion, Record<string
     attendance: Endpoint<Attendance, AttendanceQueryParams, 'user' | 'in_time'>;
     auth: Endpoint<Auth>;
     availability: Endpoint<Availability, AvailabilityQueryParams>;
-    daily_budget: Endpoint<DailyBudgets, DailyBudgetsQueryParams>;
+    daily_budgets: Endpoint<DailyBudgets, DailyBudgetsQueryParams>;
     daily_revenue: Endpoint<DailyRevenue, DailyRevenueQueryParams>;
     day_notes: Endpoint<DayNote, DayNotesQueryParams>;
     days_off: Endpoint<DaysOff, DaysOffQueryParams>;

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -91,7 +91,7 @@ export interface EndpointEntityMap extends Record<EndpointVersion, Record<string
     timezones: Endpoint<TimeZone>;
     toil_accruals: Endpoint<ToilAccrual, ToilAccrualsQueryParams, 'duration_hours' | 'leave_year' | 'user_id'>;
     toil_allowance: Endpoint<ToilAllowance, ToilAllowanceQueryParams>;
-    users_clocked_in: Endpoint<UserClockedIn, {} | undefined, 'in_method'>;
+    users_clocked_in: Endpoint<UserClockedIn, undefined, 'in_method'>;
     users: Endpoint<User, UsersQueryParams, 'first_name' | 'last_name'>;
   };
   /** Type mappings for v2 endpoints */

--- a/src/interfaces/query-params/toil-allowance-query-params.interface.ts
+++ b/src/interfaces/query-params/toil-allowance-query-params.interface.ts
@@ -1,3 +1,4 @@
 export interface ToilAllowanceQueryParams {
+  year: number;
   users?: number[];
 }

--- a/src/interfaces/user.interface.ts
+++ b/src/interfaces/user.interface.ts
@@ -48,7 +48,7 @@ export interface User {
   leave_rates_unit: string;
   leave_rates_type: string;
   notes: string | null;
-  pin: string | null;
+  pin?: string | null;
   salaried_cost_location: number | null;
   permissions: ManagerPermission[];
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,5 +2,6 @@ import { createSdkClient } from './client-builder.js';
 import { SERVICES } from './service.js';
 
 export * from './interfaces/index.js';
+export * from './interfaces/query-params/index.js';
 export * from './models/index.js';
 export const createRotaCloudClient = createSdkClient(SERVICES);

--- a/src/ops.test.ts
+++ b/src/ops.test.ts
@@ -42,6 +42,7 @@ describe('Operations', () => {
         client: mockAxiosClient,
         request: {},
         service,
+        sdkConfig: { apiKey: '' },
       },
       1,
     );

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -2,6 +2,7 @@ import { Axios, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { ServiceSpecification } from './service.js';
 import { RequestOptions, QueryParameterValue, RequirementsOf, assert } from './utils.js';
 import { Endpoint, EndpointVersion } from './endpoint.js';
+import { SDKConfig } from './main.js';
 
 /** Supported common operations */
 export type Operation =
@@ -19,6 +20,7 @@ export type OperationContext = {
   client: Readonly<Axios>;
   request: Readonly<AxiosRequestConfig>;
   service: Readonly<ServiceSpecification>;
+  sdkConfig: Readonly<SDKConfig>;
 };
 
 /** Defines the mapping between the data sent for a given request (e.g with

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -1,7 +1,7 @@
 import { Axios, AxiosRequestConfig, AxiosResponse } from 'axios';
 import assert from 'assert';
 import { ServiceSpecification } from './service.js';
-import { RequestOptions, QueryParameterValue } from './utils.js';
+import { RequestOptions, QueryParameterValue, RequirementsOf } from './utils.js';
 import { Endpoint, EndpointVersion } from './endpoint.js';
 
 // TODO: should we add "upsert"?
@@ -10,7 +10,7 @@ export type Operation = 'get' | 'list' | 'listAll' | 'delete' | 'create' | 'upda
 /** Context provided to all operations */
 export type OperationContext = {
   client: Readonly<Axios>;
-  request: Readonly<AxiosRequestConfig<unknown>>;
+  request: Readonly<AxiosRequestConfig>;
   service: Readonly<ServiceSpecification>;
 };
 
@@ -28,101 +28,100 @@ export type RequestConfig<RequestData, ResponseData> = AxiosRequestConfig<Reques
  * This is intended as a convenient way of defining {@see OpFunction}s that can then be
  * "built" ready for the end user to call ({@see buildOp})
  * */
-export type OpDef<T, P = any, O extends Partial<RequestOptions<any>> = RequestOptions<unknown>, R = T> =
-  | ((ctx: OperationContext, param: P, opts?: O) => RequestConfig<T, R>)
-  | ((ctx: OperationContext, param: P, opts?: O) => AsyncIterable<T>)
-  | ((ctx: OperationContext, param: P, opts?: O) => Promise<T>);
+export type OpDef<T, Param = any, Opts extends Partial<RequestOptions<any>> = RequestOptions<unknown>, Return = T> =
+  | ((ctx: OperationContext, param: Param, opts?: Opts) => RequestConfig<T, Return>)
+  | ((ctx: OperationContext, param: Param, opts?: Opts) => AsyncIterable<T>)
+  | ((ctx: OperationContext, param: Param, opts?: Opts) => Promise<T>);
 
 /** Operation function type to be called by the end user of the SDK.
  *
  * All methods on services follow this typing
  * */
-export type OpFunction<R = any, Param = undefined> =
-  R extends AsyncIterable<infer U>
-    ? // List based op parameter names
-      Param extends undefined
+export type OpFunction<R = any, Param = undefined> = R extends AsyncIterable<infer U> | Promise<Iterable<infer U>>
+  ? // List based op parameter names
+    Param extends undefined
+    ? {
+        (query?: Param): R;
+        <F extends keyof U>(
+          query: Param,
+          options: { fields: F[] } & RequestOptions<U>,
+        ): Promise<AsyncIterable<Pick<U, F>>>;
+        (query: Param, opts?: RequestOptions<U>): R;
+      }
+    : Partial<Param> extends Param
       ? {
           (query?: Param): R;
           <F extends keyof U>(
             query: Param,
             options: { fields: F[] } & RequestOptions<U>,
           ): Promise<AsyncIterable<Pick<U, F>>>;
+          (query?: Param, opts?: RequestOptions<U>): R;
+        }
+      : {
+          (query: Param): R;
+          <F extends keyof U>(
+            query: Param,
+            options: { fields: F[] } & RequestOptions<U>,
+          ): Promise<AsyncIterable<Pick<U, F>>>;
           (query: Param, opts?: RequestOptions<U>): R;
         }
-      : Partial<Param> extends Param
-        ? {
-            (query?: Param): R;
-            <F extends keyof U>(
-              query: Param,
-              options: { fields: F[] } & RequestOptions<U>,
-            ): Promise<AsyncIterable<Pick<U, F>>>;
-            (query?: Param, opts?: RequestOptions<U>): R;
-          }
-        : {
-            (query: Param): R;
-            <F extends keyof U>(
-              query: Param,
-              options: { fields: F[] } & RequestOptions<U>,
-            ): Promise<AsyncIterable<Pick<U, F>>>;
-            (query: Param, opts?: RequestOptions<U>): R;
-          }
-    : Param extends number
+  : Param extends number
+    ? {
+        (id: Param): R;
+        <F extends keyof Awaited<R>>(
+          id: Param,
+          options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<R>>,
+        ): Promise<AxiosResponse<Pick<Awaited<R>, F>>>;
+        <F extends keyof Awaited<R>>(
+          id: Param,
+          options: { fields: F[] } & RequestOptions<Awaited<R>>,
+        ): Promise<Pick<Awaited<R>, F>>;
+        (
+          id: Param,
+          options?: {
+            rawResponse: true;
+          } & RequestOptions<Awaited<R>>,
+        ): Promise<AxiosResponse<Awaited<R>>>;
+        (id: Param, options?: RequestOptions<Awaited<R>>): R;
+      }
+    : Param extends undefined
       ? {
-          (id: Param): R;
+          (entity?: Param): R;
           <F extends keyof Awaited<R>>(
-            id: Param,
+            entity: Param,
             options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<R>>,
           ): Promise<AxiosResponse<Pick<Awaited<R>, F>>>;
           <F extends keyof Awaited<R>>(
-            id: Param,
+            entity: Param,
             options: { fields: F[] } & RequestOptions<Awaited<R>>,
           ): Promise<Pick<Awaited<R>, F>>;
           (
-            id: Param,
+            entity?: Param,
             options?: {
               rawResponse: true;
             } & RequestOptions<Awaited<R>>,
           ): Promise<AxiosResponse<Awaited<R>>>;
-          (id: Param, options?: RequestOptions<Awaited<R>>): R;
+          (entity?: Param, options?: RequestOptions<Awaited<R>>): R;
         }
-      : Param extends undefined
-        ? {
-            (entity?: Param): R;
-            <F extends keyof Awaited<R>>(
-              entity: Param,
-              options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<R>>,
-            ): Promise<AxiosResponse<Pick<Awaited<R>, F>>>;
-            <F extends keyof Awaited<R>>(
-              entity: Param,
-              options: { fields: F[] } & RequestOptions<Awaited<R>>,
-            ): Promise<Pick<Awaited<R>, F>>;
-            (
-              entity?: Param,
-              options?: {
-                rawResponse: true;
-              } & RequestOptions<Awaited<R>>,
-            ): Promise<AxiosResponse<Awaited<R>>>;
-            (entity?: Param, options?: RequestOptions<Awaited<R>>): R;
-          }
-        : // Entity based op parameter names
-          {
-            (entity: Param): R;
-            <F extends keyof R>(
-              entity: Param,
-              options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<R>>,
-            ): Promise<AxiosResponse<Pick<Awaited<R>, F>>>;
-            <F extends keyof R>(
-              entity: Param,
-              options: { fields: F[] } & RequestOptions<Awaited<R>>,
-            ): Promise<Pick<Awaited<R>, F>>;
-            (
-              entity: Param,
-              options?: {
-                rawResponse: true;
-              } & RequestOptions<Awaited<R>>,
-            ): Promise<AxiosResponse<Awaited<R>>>;
-            (entity: Param, options?: RequestOptions<Awaited<R>>): R;
-          };
+      : // Entity based op parameter names
+        {
+          (entity: Param): R;
+          <F extends keyof Awaited<R>>(
+            entity: Param,
+            options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<R>>,
+          ): Promise<AxiosResponse<Pick<Awaited<R>, F>>>;
+          <F extends keyof Awaited<R>>(
+            entity: Param,
+            options: { fields: F[] } & RequestOptions<Awaited<R>>,
+          ): Promise<Pick<Awaited<R>, F>>;
+          (
+            entity: Param,
+            options?: {
+              rawResponse: true;
+            } & RequestOptions<Awaited<R>>,
+          ): Promise<AxiosResponse<Awaited<R>>>;
+          (entity: Param, options?: RequestOptions<Awaited<R>>): R;
+        };
 
 /** Utility for creating a query params map needed by most API requests */
 export function paramsFromOptions<T>(opts: RequestOptions<T>): Record<string, QueryParameterValue> {
@@ -182,7 +181,7 @@ function createOp<T = unknown, NewEntity = unknown>(
 }
 
 /** Operation for updating an entity */
-function updateOp<Return, Entity extends { id: number } & Return>(
+function updateOp<Return, Entity extends { id: number } & Partial<Return>>(
   ctx: OperationContext,
   entity: Entity,
 ): RequestConfig<Entity, Return> {
@@ -298,15 +297,15 @@ export function getOpMap<E extends Endpoint<any, any>, T extends E['type'] = E['
       list: listOp<T, E['queryParameters']>,
       listAll: listAllOp<T, E['queryParameters']>,
       create: createOp<T, E['createType']>,
-      update: updateOp<T, T extends { id: number } ? T : never>,
+      update: updateOp<T, T extends { id: number } ? RequirementsOf<T, 'id'> : never>,
     },
     v2: {
       get: getOp<T>,
       delete: deleteOp,
       list: listOp<T, E['queryParameters']>,
-      listAll: listAllOp<E['queryParameters'], T>,
+      listAll: listAllOp<T, E['queryParameters']>,
       create: createOp<T, E['createType']>,
-      update: updateOp<T, T extends { id: number } ? T : never>,
+      update: updateOp<T, T extends { id: number } ? RequirementsOf<T, 'id'> : never>,
     },
   } satisfies Record<EndpointVersion, Record<Operation, OpDef<any, any>>>;
 }

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -44,7 +44,11 @@ export type OpFunction<R = any, Param = undefined> = R extends AsyncIterable<inf
         <F extends keyof U>(
           query: Param,
           options: { fields: F[] } & RequestOptions<U>,
-        ): Promise<AsyncIterable<Pick<U, F>>>;
+        ): R extends AsyncIterable<U>
+          ? Promise<AsyncIterable<Pick<U, F>>>
+          : R extends Promise<Array<U>>
+            ? Promise<Array<Pick<U, F>>>
+            : Promise<Iterable<Pick<U, F>>>;
         (query: Param, opts?: RequestOptions<U>): R;
       }
     : Partial<Param> extends Param
@@ -53,7 +57,11 @@ export type OpFunction<R = any, Param = undefined> = R extends AsyncIterable<inf
           <F extends keyof U>(
             query: Param,
             options: { fields: F[] } & RequestOptions<U>,
-          ): Promise<AsyncIterable<Pick<U, F>>>;
+          ): R extends AsyncIterable<U>
+            ? Promise<AsyncIterable<Pick<U, F>>>
+            : R extends Promise<Array<U>>
+              ? Promise<Array<Pick<U, F>>>
+              : Promise<Iterable<Pick<U, F>>>;
           (query?: Param, opts?: RequestOptions<U>): R;
         }
       : {
@@ -61,7 +69,11 @@ export type OpFunction<R = any, Param = undefined> = R extends AsyncIterable<inf
           <F extends keyof U>(
             query: Param,
             options: { fields: F[] } & RequestOptions<U>,
-          ): Promise<AsyncIterable<Pick<U, F>>>;
+          ): R extends AsyncIterable<U>
+            ? Promise<AsyncIterable<Pick<U, F>>>
+            : R extends Promise<Array<U>>
+              ? Promise<Array<Pick<U, F>>>
+              : Promise<Iterable<Pick<U, F>>>;
           (query: Param, opts?: RequestOptions<U>): R;
         }
   : Param extends number

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -261,7 +261,7 @@ function deleteBatchOp(ctx: OperationContext, ids: number[]): RequestConfig<unkn
 /** Operation for listing all entities on an endpoint for a given query by
  * automatically handling pagination as and when needed
  */
-async function* listOp<T, Query>(
+export async function* listOp<T, Query>(
   ctx: OperationContext,
   query: Query,
   // NOTE: offset is only supported in v1
@@ -294,7 +294,7 @@ async function* listOp<T, Query>(
 }
 
 /** Operation for listing all entities on an endpoint for a given query as an array */
-async function listAllOp<T, Query>(
+export async function listAllOp<T, Query>(
   ctx: OperationContext,
   query: Query,
   // NOTE: offset is only supported in v1

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -6,7 +6,7 @@ import { Endpoint, EndpointVersion } from './endpoint.js';
 
 // TODO: should we add "upsert"?
 /** Supported common operations */
-export type Operation = 'get' | 'list' | 'listAll' | 'delete' | 'create' | 'update';
+export type Operation = 'get' | 'list' | 'listAll' | 'delete' | 'deleteBatch' | 'create' | 'update';
 /** Context provided to all operations */
 export type OperationContext = {
   client: Readonly<Axios>;
@@ -202,6 +202,16 @@ function deleteOp(ctx: OperationContext, id: number): RequestConfig<unknown, voi
   };
 }
 
+/** Operation for deleting a list of entities */
+function deleteBatchOp(ctx: OperationContext, ids: number[]): RequestConfig<unknown, void> {
+  return {
+    ...ctx.request,
+    method: 'DELETE',
+    url: `${ctx.service.endpointVersion}/${ctx.service.endpoint}`,
+    data: ids,
+  };
+}
+
 /** Operation for listing all entities on an endpoint for a given query by
  * automatically handling pagination as and when needed
  */
@@ -294,6 +304,7 @@ export function getOpMap<E extends Endpoint<any, any>, T extends E['type'] = E['
     v1: {
       get: getOp<T>,
       delete: deleteOp,
+      deleteBatch: deleteBatchOp,
       list: listOp<T, E['queryParameters']>,
       listAll: listAllOp<T, E['queryParameters']>,
       create: createOp<T, E['createType']>,
@@ -302,6 +313,7 @@ export function getOpMap<E extends Endpoint<any, any>, T extends E['type'] = E['
     v2: {
       get: getOp<T>,
       delete: deleteOp,
+      deleteBatch: deleteBatchOp,
       list: listOp<T, E['queryParameters']>,
       listAll: listAllOp<T, E['queryParameters']>,
       create: createOp<T, E['createType']>,

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -49,14 +49,23 @@ export type OpFunction<R = any, Param = undefined> =
           ): Promise<AsyncIterable<Pick<U, F>>>;
           (query: Param, opts?: RequestOptions<U>): R;
         }
-      : {
-          (query: Param): R;
-          <F extends keyof U>(
-            query: Param,
-            options: { fields: F[] } & RequestOptions<U>,
-          ): Promise<AsyncIterable<Pick<U, F>>>;
-          (query: Param, opts?: RequestOptions<U>): R;
-        }
+      : Partial<Param> extends Param
+        ? {
+            (query?: Param): R;
+            <F extends keyof U>(
+              query: Param,
+              options: { fields: F[] } & RequestOptions<U>,
+            ): Promise<AsyncIterable<Pick<U, F>>>;
+            (query?: Param, opts?: RequestOptions<U>): R;
+          }
+        : {
+            (query: Param): R;
+            <F extends keyof U>(
+              query: Param,
+              options: { fields: F[] } & RequestOptions<U>,
+            ): Promise<AsyncIterable<Pick<U, F>>>;
+            (query: Param, opts?: RequestOptions<U>): R;
+          }
     : Param extends number
       ? {
           (id: Param): R;

--- a/src/service.ts
+++ b/src/service.ts
@@ -239,9 +239,7 @@ export const SERVICES = {
       }),
       updateSwap: (
         { request },
-        swapRequest:
-          | RequirementsOf<ShiftSwapRequest, 'id' | 'admin_approved'>
-          | RequirementsOf<ShiftSwapRequest, 'id' | 'user_approved'>,
+        swapRequest: RequirementsOf<ShiftSwapRequest, 'id'>,
       ): RequestConfig<{ admin_approved: boolean } | { user_approved: boolean }, ShiftSwapRequest> => {
         let payload: { admin_approved: boolean } | { user_approved: boolean } | undefined;
         if (swapRequest.admin_approved !== null && swapRequest.admin_approved !== undefined) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -8,16 +8,18 @@ import {
   LeaveType,
   ShiftHistoryRecord,
   Terminal,
+  ToilAllowance,
   UserBreak,
   UserClockedIn,
   UserClockedOut,
 } from './interfaces/index.js';
 import { LaunchTerminal } from './interfaces/launch-terminal.interface.js';
-import { OpDef, Operation, OperationContext, RequestConfig, paramsFromOptions } from './ops.js';
+import { OpDef, Operation, OperationContext, RequestConfig, listAllOp, listOp, paramsFromOptions } from './ops.js';
 import { UserBreakRequest, UserClockIn, UserClockOut } from './interfaces/user-clock-in.interface.js';
 import { RequirementsOf, RequestOptions } from './utils.js';
 import { ShiftSwapRequest } from './interfaces/swap-request.interface.js';
 import { ShiftDropRequest } from './interfaces/drop-request.interface.js';
+import { ToilAllowanceQueryParams } from './interfaces/query-params/index.js';
 
 export type ServiceSpecification<CustomOp extends OpDef<unknown> = OpDef<any>> = {
   /** Operations allowed and usable for the endpoint */
@@ -311,6 +313,36 @@ export const SERVICES = {
     endpoint: 'toil_allowance',
     endpointVersion: 'v1',
     operations: ['list', 'listAll'],
+    customOperations: {
+      list: (ctx, query: ToilAllowanceQueryParams, opts) =>
+        // Maps the "year" query parameter into the endpoint URL
+        listOp<ToilAllowance, Omit<typeof query, 'year'>>(
+          {
+            ...ctx,
+            service: {
+              ...ctx.service,
+              endpoint: `${ctx.service.endpoint}/${query.year}` as typeof ctx.service.endpoint,
+              endpointVersion: 'v1',
+            },
+          },
+          { users: query.users },
+          opts,
+        ),
+      listAll: (ctx, query: ToilAllowanceQueryParams, opts) =>
+        // Maps the "year" query parameter into the endpoint URL
+        listAllOp<ToilAllowance, Omit<typeof query, 'year'>>(
+          {
+            ...ctx,
+            service: {
+              ...ctx.service,
+              endpoint: `${ctx.service.endpoint}/${query.year}` as typeof ctx.service.endpoint,
+              endpointVersion: 'v1',
+            },
+          },
+          { users: query.users },
+          opts,
+        ),
+    },
   },
   userClockIn: {
     endpoint: 'users_clocked_in',

--- a/src/service.ts
+++ b/src/service.ts
@@ -102,9 +102,9 @@ export const SERVICES = {
   dailyBudget: {
     endpoint: 'daily_budgets',
     endpointVersion: 'v1',
-    operations: ['list', 'listAll', 'update'],
+    operations: ['list', 'listAll', 'updateBatch'],
     customOperations: {
-      update: ({ request, service }, entities: DailyBudgets[]): RequestConfig<typeof entities, void> => ({
+      updateBatch: ({ request, service }, entities: DailyBudgets[]): RequestConfig<typeof entities, void> => ({
         ...request,
         method: 'POST',
         url: service.endpoint,
@@ -115,9 +115,9 @@ export const SERVICES = {
   dailyRevenue: {
     endpoint: 'daily_revenue',
     endpointVersion: 'v1',
-    operations: ['list', 'listAll', 'update'],
+    operations: ['list', 'listAll', 'updateBatch'],
     customOperations: {
-      update: ({ request, service }, entities: DailyRevenue[]): RequestConfig<typeof entities, void> => ({
+      updateBatch: ({ request, service }, entities: DailyRevenue[]): RequestConfig<typeof entities, void> => ({
         ...request,
         method: 'POST',
         url: service.endpoint,

--- a/src/service.ts
+++ b/src/service.ts
@@ -163,7 +163,7 @@ export const SERVICES = {
     operations: ['get', 'list', 'listAll', 'delete', 'create', 'update'],
     customOperations: {
       create: (
-        { request, service }: OperationContext,
+        { request, service, sdkConfig }: OperationContext,
         entity: EndpointEntityMap['v1']['leave']['createType'],
         opts?: RequestOptions<Leave>,
       ): RequestConfig<typeof entity, Leave[]> => ({
@@ -173,7 +173,7 @@ export const SERVICES = {
         data: entity,
         headers: {
           ...request.headers,
-          Account: undefined,
+          Account: sdkConfig.accountId,
           User: entity.user,
         },
         params: {

--- a/src/service.ts
+++ b/src/service.ts
@@ -65,7 +65,7 @@ export const SERVICES = {
     customOperations: {
       get: ({ request, service }): RequestConfig<void, Auth> => ({
         ...request,
-        url: service.endpoint,
+        url: `${service.endpointVersion}/${service.endpoint}`,
         method: 'GET',
       }),
     },
@@ -78,7 +78,7 @@ export const SERVICES = {
       update: ({ request, service }, entity: Availability): RequestConfig<typeof entity, Availability> => ({
         ...request,
         method: 'POST',
-        url: service.endpoint,
+        url: `${service.endpointVersion}/${service.endpoint}`,
         data: entity,
       }),
       delete: (
@@ -87,7 +87,7 @@ export const SERVICES = {
       ): RequestConfig<Availability, Availability> => ({
         ...request,
         method: 'POST',
-        url: service.endpoint,
+        url: `${service.endpointVersion}/${service.endpoint}`,
         data: {
           ...entity,
           dates: entity.dates.map((date) => ({
@@ -107,7 +107,7 @@ export const SERVICES = {
       updateBatch: ({ request, service }, entities: DailyBudgets[]): RequestConfig<typeof entities, void> => ({
         ...request,
         method: 'POST',
-        url: service.endpoint,
+        url: `${service.endpointVersion}/${service.endpoint}`,
         data: entities,
       }),
     },
@@ -120,7 +120,7 @@ export const SERVICES = {
       updateBatch: ({ request, service }, entities: DailyRevenue[]): RequestConfig<typeof entities, void> => ({
         ...request,
         method: 'POST',
-        url: service.endpoint,
+        url: `${service.endpointVersion}/${service.endpoint}`,
         data: entities,
       }),
     },
@@ -167,7 +167,7 @@ export const SERVICES = {
       ): RequestConfig<typeof entity, Leave[]> => ({
         ...request,
         method: 'POST',
-        url: service.endpoint,
+        url: `${service.endpointVersion}/${service.endpoint}`,
         data: entity,
         headers: {
           ...request.headers,

--- a/src/service.ts
+++ b/src/service.ts
@@ -179,7 +179,7 @@ export const SERVICES = {
   shift: {
     endpoint: 'shifts',
     endpointVersion: 'v1',
-    operations: ['create', 'get', 'list', 'listAll', 'update', 'delete'],
+    operations: ['create', 'get', 'list', 'listAll', 'update', 'updateBatch', 'delete', 'deleteBatch'],
     customOperations: {
       acknowledge: ({ request }, shiftIds: number[]): RequestConfig<{ shifts: number[] }, void> => ({
         ...request,

--- a/src/service.ts
+++ b/src/service.ts
@@ -179,14 +179,11 @@ export const SERVICES = {
           ...paramsFromOptions(opts ?? {}),
         },
       }),
-      types: ({ request }): RequestConfig<void, LeaveType[]> => {
-        const req = {
-          ...request,
-          method: 'GET',
-          url: 'v1/leave_types',
-        };
-        return req;
-      },
+      types: ({ request }): RequestConfig<void, LeaveType[]> => ({
+        ...request,
+        method: 'GET',
+        url: 'v1/leave_types',
+      }),
     },
   },
   location: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,8 +161,6 @@ export function getBaseRequestConfig(opts: SDKConfig): AxiosRequestConfig<unknow
   }
 
   // Set last to prevent being overridden
-  // if (typeof opts.apiKey !== 'string' && typeof opts.basicAuth !== 'string')
-  //   throw new SDKError({ message: 'No auth provided to SDK' });
   headers.Authorization = opts.apiKey ? `Bearer ${opts.apiKey}` : `Basic ${opts.basicAuth}`;
   headers['SDK-Version'] = pkg.version;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,8 @@
 import axios, { Axios, AxiosError, AxiosRequestConfig, isAxiosError } from 'axios';
 import axiosRetry, { isNetworkOrIdempotentRequestError } from 'axios-retry';
-import assert from 'assert';
 import { RetryOptions, RetryStrategy, SDKConfig } from './interfaces/index.js';
 import { SDKError } from './models/index.js';
-import { version } from '../package.json' assert { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 
 /** Creates a `Partial<T>` where all properties specified by `K` are required
  *
@@ -46,6 +45,17 @@ const DEFAULT_RETRY_STRATEGY_OPTIONS: Record<RetryStrategy, RetryOptions> = {
     delay: DEFAULT_RETRY_DELAY,
   },
 };
+
+class AssertionError extends Error {
+  override name = AssertionError.prototype.name;
+}
+
+export function assert(value: unknown, message?: string | Error): asserts value {
+  if (value) return;
+  if (!message || typeof message === 'string')
+    throw new AssertionError(message ?? `Assertion failed - value = ${value}`);
+  throw message;
+}
 
 function parseClientError(error: AxiosError): SDKError {
   const axiosErrorLocation = error.response || error.request;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,10 +148,7 @@ export function createCustomAxiosClient(config: Readonly<SDKConfig>): Axios {
  * for an {@see OpFunction} to adapt/use
  */
 export function getBaseRequestConfig(opts: SDKConfig): AxiosRequestConfig<unknown> {
-  const headers: Record<string, string> = {
-    Authorization: opts.apiKey ? `Bearer ${opts.apiKey}` : `Basic ${opts.basicAuth}`,
-    'SDK-Version': version,
-  };
+  const headers: Record<string, string> = {};
 
   const extraHeaders = opts.headers;
   if (extraHeaders && typeof extraHeaders === 'object') {
@@ -162,6 +159,12 @@ export function getBaseRequestConfig(opts: SDKConfig): AxiosRequestConfig<unknow
   if (opts.accountId) {
     headers.Account = String(opts.accountId);
   }
+
+  // Set last to prevent being overridden
+  // if (typeof opts.apiKey !== 'string' && typeof opts.basicAuth !== 'string')
+  //   throw new SDKError({ message: 'No auth provided to SDK' });
+  headers.Authorization = opts.apiKey ? `Bearer ${opts.apiKey}` : `Basic ${opts.basicAuth}`;
+  headers['SDK-Version'] = pkg.version;
 
   return {
     headers,


### PR DESCRIPTION
# Overview
- Added features previously available in version one but were missed during the upgrade to v2
- Improved documentation for the `README.md` to get started and added many missing JSDoc comments
- Replaced Node specific packages to ensure compatibility with the web

## Features
- Batch ops: `deleteBatch` and `updateBatch`
  - These were implicitly available for certain service methods in v1 now explicit callable ops in v2
- Op for listing by page: `listByPage`
  - Previously available in v1 
- Updated `README` to reflect v2
- Add the SDK config to `OperationContext`
  - Useful for custom operations that need reference to the provided config (in this case the `leave.create` method needs the account ID supplied by the config)

## Fixes
- `auth.get` op no longer insists on an entity ID (v1 behaviour)
-  `availability` `update` and `delete` ops are no longer entity ID based and work off dates (v1 behaviour)
- Typo fix for endpoint URL `daily_budgets`
- Support `updateBatch` ops for `daily_budgets` and `daily_revenue`
- Add missing `update` op for `leave`
- Fix entity typing for `leave.create` op
- Add missing `updateBatch` and `deleteBatch` ops for `shift`
- Fix types for `shift.updateSwap` and `shift.updateDrop` ops
- Add support for `toil.listByPage` op
- Write key SDK headers last when building the base request to prevent being overridden
- Fix types primarily around list op definitions
- Fix raw fetch method not applying base request config 