### PR TITLE
misc/pagination-v1-fix - fix: paginated v1 calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "type": "module",
   "engines": {

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -303,7 +303,7 @@ export async function* listOp<T, Query>(
   yield* res.data.slice(0, maxEntities);
   if (entityCount >= maxEntities) return;
 
-  for (const pagedRequest of requestPaginated(res, ctx.request)) {
+  for (const pagedRequest of requestPaginated(res, queriedRequest)) {
     const pagedRes = await ctx.client.request<T[]>(pagedRequest);
     for (const entity of pagedRes.data) {
       yield entity;
@@ -407,7 +407,7 @@ async function* listByPageOp<T, Query>(
   yield res;
   if (entityCount >= maxEntities) return;
 
-  for (const pagedRequest of requestPaginated(res, ctx.request)) {
+  for (const pagedRequest of requestPaginated(res, queriedRequest)) {
     const pagedRes = await ctx.client.request<T[]>(pagedRequest);
     yield pagedRes;
     entityCount += pagedRes.data.length;


### PR DESCRIPTION
Fixed op for v1 pagination where the request context used to base subsequent paged calls from was missing the URL and setup used for the first page call