### PR TITLE
bug/PLAT-630 - fix: terminalActive service with correct URL endpoint and types for custom ops

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "type": "module",
   "engines": {

--- a/src/service.ts
+++ b/src/service.ts
@@ -344,19 +344,24 @@ export const SERVICES = {
     },
   },
   terminalActive: {
-    endpoint: 'terminals',
+    endpoint: 'terminals_active',
     endpointVersion: 'v1',
     operations: ['list', 'listAll'],
     customOperations: {
-      launch: ({ request, service }, id: LaunchTerminal): RequestConfig<void, Terminal> => ({
+      launch: ({ request, service }, terminal: LaunchTerminal): RequestConfig<LaunchTerminal, Terminal> => ({
         ...request,
-        method: 'DELETE',
-        url: `${service.endpointVersion}/${service.endpoint}/${id}`,
+        method: 'POST',
+        url: `${service.endpointVersion}/${service.endpoint}`,
+        data: terminal,
       }),
-      ping: ({ request, service }, id: { id: number; action: string; device: string }): RequestConfig<void, void> => ({
+      ping: (
+        { request, service },
+        terminal: { id: number; action: string; device: string },
+      ): RequestConfig<Omit<typeof terminal, 'id'>, void> => ({
         ...request,
-        method: 'DELETE',
-        url: `${service.endpointVersion}/${service.endpoint}/${id}`,
+        method: 'POST',
+        url: `${service.endpointVersion}/${service.endpoint}/${terminal.id}`,
+        data: { action: terminal.action, device: terminal.device },
       }),
       close: ({ request, service }, id: number): RequestConfig<void, void> => ({
         ...request,


### PR DESCRIPTION
Fixes the service definition for `terminalActive` service which was left as a copy of the `terminal` service and missing the correct endpoint URL as well as the the right calls for the `customOperations`: `ping` and `launch`