### PR TITLE
bug/v1-error-messages - fix: v1 error messages not being shown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "type": "module",
   "engines": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ function toSearchParams(parameters?: Record<string, QueryParameterValue>): URLSe
 
 function parseClientError(error: AxiosError): SDKError {
   const axiosErrorLocation = error.response || error.request;
-  const apiErrorMessage = axiosErrorLocation.data?.message;
+  const apiErrorMessage = axiosErrorLocation.data?.message ?? axiosErrorLocation.data?.error;
   let url: URL | undefined;
   try {
     url = new URL(error.config?.url ?? '', error.config?.baseURL);


### PR DESCRIPTION
Fixes a bug in which getting an error from a v1 endpoint wouldn't pull through the error message correctly into `SDKError`s