### PR TITLE
feat/memos - feat: add support for the `/v1/messages` endpoint and associated types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "2.1.5",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "type": "module",
   "engines": {

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -100,7 +100,10 @@ export interface EndpointEntityMap extends Record<EndpointVersion, Record<string
     messages: Endpoint<
       Message,
       undefined,
-      Pick<Message, 'message' | 'subject'> & { users: number[]; attachments?: Message['attachments'] }
+      Pick<Message, 'message' | 'subject'> & {
+        users: number[];
+        attachments?: Pick<Message['attachments'][number], 'key' | 'bucket' | 'name' | 'extension'>[];
+      }
     >;
     pins: Endpoint<Pin>;
     roles: Endpoint<Role, RolesQueryParams, 'name'>;

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -29,6 +29,7 @@ import {
   DayNoteV2QueryParameters,
 } from './interfaces/index.js';
 import { LogbookEntry, LogbookQueryParameters } from './interfaces/logbook.interface.js';
+import { Message } from './interfaces/message.interface.js';
 import {
   AttendanceQueryParams,
   AvailabilityQueryParams,
@@ -58,7 +59,7 @@ export type EndpointVersion = 'v1' | 'v2';
 export type Endpoint<
   Entity,
   QueryParameters = undefined,
-  CreateEntity extends keyof Entity | Partial<Entity> = any,
+  CreateEntity extends keyof Entity | object = any,
   // NOTE: introduced to work around TS inferring `RequirementsOf<Entity, CreateEntity>` incorrectly
   // TS resolves type to:
   // `RequirementsOf<Entity, "key 1"> | RequirementsOf<Entity "key 2">`
@@ -96,6 +97,11 @@ export interface EndpointEntityMap extends Record<EndpointVersion, Record<string
     leave_types: Endpoint<LeaveType>;
     leave: Endpoint<Leave, LeaveQueryParams, 'users' | 'type' | 'start_date' | 'end_date'>;
     locations: Endpoint<Location, LocationsQueryParams, 'name'>;
+    messages: Endpoint<
+      Message,
+      undefined,
+      Pick<Message, 'message' | 'subject'> & { users: number[]; attachments?: Message['attachments'] }
+    >;
     pins: Endpoint<Pin>;
     roles: Endpoint<Role, RolesQueryParams, 'name'>;
     settings: Endpoint<Settings, SettingsQueryParams>;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -36,3 +36,4 @@ export * from './user.interface.js';
 export * from './users-clocked-in.interface.js';
 export * from './users-clocked-out.interface.js';
 export * from './document.interface.js';
+export * from './message.interface.js';

--- a/src/interfaces/message.interface.ts
+++ b/src/interfaces/message.interface.ts
@@ -13,7 +13,7 @@ export interface Message {
     opened: boolean;
     /** Unix timestamp in seconds */
     opened_at: boolean;
-    error: null | unknown;
+    error: string | null;
   }[];
   attachments: {
     name: string;

--- a/src/interfaces/message.interface.ts
+++ b/src/interfaces/message.interface.ts
@@ -1,0 +1,27 @@
+export interface Message {
+  id: number;
+  /** Unix timestamp in seconds */
+  sent_at: number;
+  sent_by: number;
+  subject: string;
+  message: string;
+  /** User recipients of the message */
+  users: {
+    /** ID of user */
+    user: number;
+    sent: boolean;
+    opened: boolean;
+    /** Unix timestamp in seconds */
+    opened_at: boolean;
+    error: null | unknown;
+  }[];
+  attachments: {
+    name: string;
+    extension: string;
+    type: string;
+    /** rounded integer value */
+    size_kb: number;
+    bucket: string;
+    key: string;
+  }[];
+}

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -241,7 +241,7 @@ function getOp<T = undefined>(ctx: OperationContext, id: number): RequestConfig<
 }
 
 /** Operation for creating an entity */
-function createOp<T = unknown, NewEntity = unknown>(
+export function createOp<T = unknown, NewEntity = unknown>(
   ctx: OperationContext,
   newEntity: NewEntity,
 ): RequestConfig<NewEntity, T> {

--- a/src/service.ts
+++ b/src/service.ts
@@ -19,6 +19,7 @@ import {
   Operation,
   OperationContext,
   RequestConfig,
+  createOp,
   listAllOp,
   listAllV2Op,
   listOp,
@@ -31,6 +32,7 @@ import { ShiftSwapRequest } from './interfaces/swap-request.interface.js';
 import { ShiftDropRequest } from './interfaces/drop-request.interface.js';
 import { ToilAllowanceQueryParams } from './interfaces/query-params/index.js';
 import { LogbookEntry, LogbookQueryParameters } from './interfaces/logbook.interface.js';
+import { Message } from './interfaces/message.interface.js';
 
 export type ServiceSpecification<CustomOp extends OpDef<unknown> = OpDef<any>> = {
   /** Operations allowed and usable for the endpoint */
@@ -264,6 +266,14 @@ export const SERVICES = {
         endpointVersion: 'v2',
         operations: ['get', 'create', 'update', 'delete', 'list', 'listAll'],
       },
+    },
+  },
+  message: {
+    endpoint: 'messages',
+    endpointVersion: 'v1',
+    operations: ['list', 'listAll', 'listByPage'],
+    customOperations: {
+      send: (ctx, message: EndpointEntityMap['v1']['messages']['createType']) => createOp<Message>(ctx, message),
     },
   },
   pin: {


### PR DESCRIPTION
# Overview
Setup a service for "memos" (`/v1/messages`) with all associated types
This had been missed previously and is not a new endpoint but is now fully supported.

I've opted for aliasing the `create` op as `send` in keeping with the memo/message analogy (hoping to make using this service more intuitive)

## What's changed
- As part of this change I've made the `createOp` public to be used within custom methods so aliases are easier to set up
- Relaxed `CreateEntity` typing to insist on `object` rather than subsets of `Entity` within the `Endpoint` parameters and memos has shown this is not always the case.