### PR TITLE
Update Timezone type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "type": "module",
   "engines": {

--- a/src/interfaces/time-zone.interface.ts
+++ b/src/interfaces/time-zone.interface.ts
@@ -3,5 +3,5 @@ export interface TimeZone {
   name: string;
   continent: string;
   city: string;
-  sub: string;
+  sub: string | null;
 }


### PR DESCRIPTION
Updates the TimeZone type to reflect that `sub` property on Timezone can be null. 

I noticed this while working on the Terminal app as we were getting a Type error. 

Here is evidence of the `sub` prop as null in the API response:

<img width="193" alt="Screenshot 2025-07-07 at 10 40 14" src="https://github.com/user-attachments/assets/e80165a4-dc59-4fcc-a7dc-d1f8315e2529" />

API docs already reflect that `sub` can be null, both Swagger and Apiary show it as being null: 
<img width="388" alt="Screenshot 2025-07-07 at 10 41 26" src="https://github.com/user-attachments/assets/a437e302-e511-441d-a301-fb98064c49eb" />
<img width="415" alt="Screenshot 2025-07-07 at 10 41 53" src="https://github.com/user-attachments/assets/fa960ec1-0c47-4f8e-a3f7-956a28c3a627" />
