### PR TITLE
docs: add missing doc comments and support `number[]` param type signatures in ops

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "type": "module",
   "engines": {

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -51,124 +51,124 @@ export type OpFunction<Return = any, Param = undefined, Opts = RequestOptions<un
   | AsyncIterable<infer U>
   | Promise<Iterable<infer U>>
   ? // List based op parameter names
-  Param extends undefined
-  ? {
-    (query?: Param): Return;
-    <F extends keyof U>(
-      query: Param,
-      options: { fields: F[] } & RequestOptions<U>,
-    ): Return extends AsyncIterable<U>
-      ? Promise<AsyncIterable<Pick<U, F>>>
-      : Return extends Promise<Array<U>>
-      ? Promise<Array<Pick<U, F>>>
-      : Promise<Iterable<Pick<U, F>>>;
-    (query: Param, options?: Opts): Return;
-  }
-  : Partial<Param> extends Param
-  ? {
-    (query?: Param): Return;
-    <F extends keyof U>(
-      query: Param,
-      options: { fields: F[] } & RequestOptions<U>,
-    ): Return extends AsyncIterable<U>
-      ? Promise<AsyncIterable<Pick<U, F>>>
-      : Return extends Promise<Array<U>>
-      ? Promise<Array<Pick<U, F>>>
-      : Promise<Iterable<Pick<U, F>>>;
-    (query?: Param, options?: Opts): Return;
-  }
-  : {
-    (query: Param): Return;
-    <F extends keyof U>(
-      query: Param,
-      options: { fields: F[] } & RequestOptions<U>,
-    ): Return extends AsyncIterable<U>
-      ? Promise<AsyncIterable<Pick<U, F>>>
-      : Return extends Promise<Array<U>>
-      ? Promise<Array<Pick<U, F>>>
-      : Promise<Iterable<Pick<U, F>>>;
-    (query: Param, Options?: Opts): Return;
-  }
+    Param extends undefined
+    ? {
+        (query?: Param): Return;
+        <F extends keyof U>(
+          query: Param,
+          options: { fields: F[] } & RequestOptions<U>,
+        ): Return extends AsyncIterable<U>
+          ? Promise<AsyncIterable<Pick<U, F>>>
+          : Return extends Promise<Array<U>>
+            ? Promise<Array<Pick<U, F>>>
+            : Promise<Iterable<Pick<U, F>>>;
+        (query: Param, options?: Opts): Return;
+      }
+    : Partial<Param> extends Param
+      ? {
+          (query?: Param): Return;
+          <F extends keyof U>(
+            query: Param,
+            options: { fields: F[] } & RequestOptions<U>,
+          ): Return extends AsyncIterable<U>
+            ? Promise<AsyncIterable<Pick<U, F>>>
+            : Return extends Promise<Array<U>>
+              ? Promise<Array<Pick<U, F>>>
+              : Promise<Iterable<Pick<U, F>>>;
+          (query?: Param, options?: Opts): Return;
+        }
+      : {
+          (query: Param): Return;
+          <F extends keyof U>(
+            query: Param,
+            options: { fields: F[] } & RequestOptions<U>,
+          ): Return extends AsyncIterable<U>
+            ? Promise<AsyncIterable<Pick<U, F>>>
+            : Return extends Promise<Array<U>>
+              ? Promise<Array<Pick<U, F>>>
+              : Promise<Iterable<Pick<U, F>>>;
+          (query: Param, Options?: Opts): Return;
+        }
   : // ID based op parameters
-  Param extends number
-  ? {
-    (id: Param): Return;
-    <F extends keyof Awaited<Return>>(
-      id: Param,
-      options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<Return>>,
-    ): Promise<AxiosResponse<Pick<Awaited<Return>, F>>>;
-    <F extends keyof Awaited<Return>>(
-      id: Param,
-      options: { fields: F[] } & RequestOptions<Awaited<Return>>,
-    ): Promise<Pick<Awaited<Return>, F>>;
-    (
-      id: Param,
-      options?: {
-        rawResponse: true;
-      } & RequestOptions<Awaited<Return>>,
-    ): Promise<AxiosResponse<Awaited<Return>>>;
-    (id: Param, options?: RequestOptions<Awaited<Return>>): Return;
-  }
-  : Param extends number[]
-  ? {
-    (ids: Param): Return;
-    <F extends keyof Awaited<Return>>(
-      ids: Param,
-      options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<Return>>,
-    ): Promise<AxiosResponse<Pick<Awaited<Return>, F>>>;
-    <F extends keyof Awaited<Return>>(
-      ids: Param,
-      options: { fields: F[] } & RequestOptions<Awaited<Return>>,
-    ): Promise<Pick<Awaited<Return>, F>>;
-    (
-      ids: Param,
-      options?: {
-        rawResponse: true;
-      } & RequestOptions<Awaited<Return>>,
-    ): Promise<AxiosResponse<Awaited<Return>>>;
-    (ids: Param, options?: RequestOptions<Awaited<Return>>): Return;
-  }
-  : // Undefined based op parameters - ensures ops that don't require a
-  // param aren't forced to specify `undefined` but can if they need to specify
-  // options
-  Param extends undefined
-  ? {
-    (): Return;
-    <F extends keyof Awaited<Return>>(
-      none: Param,
-      options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<Return>>,
-    ): Promise<AxiosResponse<Pick<Awaited<Return>, F>>>;
-    <F extends keyof Awaited<Return>>(
-      none: Param,
-      options: { fields: F[] } & RequestOptions<Awaited<Return>>,
-    ): Promise<Pick<Awaited<Return>, F>>;
-    (
-      none?: Param,
-      options?: {
-        rawResponse: true;
-      } & RequestOptions<Awaited<Return>>,
-    ): Promise<AxiosResponse<Awaited<Return>>>;
-    (none?: Param, options?: RequestOptions<Awaited<Return>>): Return;
-  }
-  : // Entity based op parameter names
-  {
-    (entity: Param): Return;
-    <F extends keyof Awaited<Return>>(
-      entity: Param,
-      options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<Return>>,
-    ): Promise<AxiosResponse<Pick<Awaited<Return>, F>>>;
-    <F extends keyof Awaited<Return>>(
-      entity: Param,
-      options: { fields: F[] } & RequestOptions<Awaited<Return>>,
-    ): Promise<Pick<Awaited<Return>, F>>;
-    (
-      entity: Param,
-      options?: {
-        rawResponse: true;
-      } & RequestOptions<Awaited<Return>>,
-    ): Promise<AxiosResponse<Awaited<Return>>>;
-    (entity: Param, options?: RequestOptions<Awaited<Return>>): Return;
-  };
+    Param extends number
+    ? {
+        (id: Param): Return;
+        <F extends keyof Awaited<Return>>(
+          id: Param,
+          options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<Return>>,
+        ): Promise<AxiosResponse<Pick<Awaited<Return>, F>>>;
+        <F extends keyof Awaited<Return>>(
+          id: Param,
+          options: { fields: F[] } & RequestOptions<Awaited<Return>>,
+        ): Promise<Pick<Awaited<Return>, F>>;
+        (
+          id: Param,
+          options?: {
+            rawResponse: true;
+          } & RequestOptions<Awaited<Return>>,
+        ): Promise<AxiosResponse<Awaited<Return>>>;
+        (id: Param, options?: RequestOptions<Awaited<Return>>): Return;
+      }
+    : Param extends number[]
+      ? {
+          (ids: Param): Return;
+          <F extends keyof Awaited<Return>>(
+            ids: Param,
+            options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<Return>>,
+          ): Promise<AxiosResponse<Pick<Awaited<Return>, F>>>;
+          <F extends keyof Awaited<Return>>(
+            ids: Param,
+            options: { fields: F[] } & RequestOptions<Awaited<Return>>,
+          ): Promise<Pick<Awaited<Return>, F>>;
+          (
+            ids: Param,
+            options?: {
+              rawResponse: true;
+            } & RequestOptions<Awaited<Return>>,
+          ): Promise<AxiosResponse<Awaited<Return>>>;
+          (ids: Param, options?: RequestOptions<Awaited<Return>>): Return;
+        }
+      : // Undefined based op parameters - ensures ops that don't require a
+        // param aren't forced to specify `undefined` but can if they need to specify
+        // options
+        Param extends undefined
+        ? {
+            (): Return;
+            <F extends keyof Awaited<Return>>(
+              none: Param,
+              options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<Return>>,
+            ): Promise<AxiosResponse<Pick<Awaited<Return>, F>>>;
+            <F extends keyof Awaited<Return>>(
+              none: Param,
+              options: { fields: F[] } & RequestOptions<Awaited<Return>>,
+            ): Promise<Pick<Awaited<Return>, F>>;
+            (
+              none?: Param,
+              options?: {
+                rawResponse: true;
+              } & RequestOptions<Awaited<Return>>,
+            ): Promise<AxiosResponse<Awaited<Return>>>;
+            (none?: Param, options?: RequestOptions<Awaited<Return>>): Return;
+          }
+        : // Entity based op parameter names
+          {
+            (entity: Param): Return;
+            <F extends keyof Awaited<Return>>(
+              entity: Param,
+              options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<Return>>,
+            ): Promise<AxiosResponse<Pick<Awaited<Return>, F>>>;
+            <F extends keyof Awaited<Return>>(
+              entity: Param,
+              options: { fields: F[] } & RequestOptions<Awaited<Return>>,
+            ): Promise<Pick<Awaited<Return>, F>>;
+            (
+              entity: Param,
+              options?: {
+                rawResponse: true;
+              } & RequestOptions<Awaited<Return>>,
+            ): Promise<AxiosResponse<Awaited<Return>>>;
+            (entity: Param, options?: RequestOptions<Awaited<Return>>): Return;
+          };
 
 /** Wrapper type for expressing the response returned by a v2 list op supported endpoint */
 interface PagedResponse<T> {

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -37,7 +37,7 @@ export type RequestConfig<RequestData, ResponseData> = AxiosRequestConfig<Reques
  *
  * This is intended as a convenient way of defining {@see OpFunction}s that can then be
  * "built" ready for the end user to call ({@see buildOp})
- * */
+ */
 export type OpDef<T, Param = any, Opts extends Partial<RequestOptions<any>> = RequestOptions<unknown>, Return = T> =
   | ((ctx: OperationContext, param: Param, opts?: Opts) => RequestConfig<T, Return>)
   | ((ctx: OperationContext, param: Param, opts?: Opts) => AsyncIterable<T>)
@@ -45,107 +45,130 @@ export type OpDef<T, Param = any, Opts extends Partial<RequestOptions<any>> = Re
 
 /** Operation function type to be called by the end user of the SDK.
  *
- * All methods on services follow this typing
- * */
-export type OpFunction<R = any, Param = undefined, Opts = RequestOptions<unknown>> = R extends
+ * All methods on services follow this typing.
+ */
+export type OpFunction<Return = any, Param = undefined, Opts = RequestOptions<unknown>> = Return extends
   | AsyncIterable<infer U>
   | Promise<Iterable<infer U>>
   ? // List based op parameter names
-    Param extends undefined
-    ? {
-        (query?: Param): R;
-        <F extends keyof U>(
-          query: Param,
-          options: { fields: F[] } & RequestOptions<U>,
-        ): R extends AsyncIterable<U>
-          ? Promise<AsyncIterable<Pick<U, F>>>
-          : R extends Promise<Array<U>>
-            ? Promise<Array<Pick<U, F>>>
-            : Promise<Iterable<Pick<U, F>>>;
-        (query: Param, options?: Opts): R;
-      }
-    : Partial<Param> extends Param
-      ? {
-          (query?: Param): R;
-          <F extends keyof U>(
-            query: Param,
-            options: { fields: F[] } & RequestOptions<U>,
-          ): R extends AsyncIterable<U>
-            ? Promise<AsyncIterable<Pick<U, F>>>
-            : R extends Promise<Array<U>>
-              ? Promise<Array<Pick<U, F>>>
-              : Promise<Iterable<Pick<U, F>>>;
-          (query?: Param, options?: Opts): R;
-        }
-      : {
-          (query: Param): R;
-          <F extends keyof U>(
-            query: Param,
-            options: { fields: F[] } & RequestOptions<U>,
-          ): R extends AsyncIterable<U>
-            ? Promise<AsyncIterable<Pick<U, F>>>
-            : R extends Promise<Array<U>>
-              ? Promise<Array<Pick<U, F>>>
-              : Promise<Iterable<Pick<U, F>>>;
-          (query: Param, Options?: Opts): R;
-        }
-  : Param extends number
-    ? {
-        (id: Param): R;
-        <F extends keyof Awaited<R>>(
-          id: Param,
-          options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<R>>,
-        ): Promise<AxiosResponse<Pick<Awaited<R>, F>>>;
-        <F extends keyof Awaited<R>>(
-          id: Param,
-          options: { fields: F[] } & RequestOptions<Awaited<R>>,
-        ): Promise<Pick<Awaited<R>, F>>;
-        (
-          id: Param,
-          options?: {
-            rawResponse: true;
-          } & RequestOptions<Awaited<R>>,
-        ): Promise<AxiosResponse<Awaited<R>>>;
-        (id: Param, options?: RequestOptions<Awaited<R>>): R;
-      }
-    : Param extends undefined
-      ? {
-          (entity?: Param): R;
-          <F extends keyof Awaited<R>>(
-            entity: Param,
-            options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<R>>,
-          ): Promise<AxiosResponse<Pick<Awaited<R>, F>>>;
-          <F extends keyof Awaited<R>>(
-            entity: Param,
-            options: { fields: F[] } & RequestOptions<Awaited<R>>,
-          ): Promise<Pick<Awaited<R>, F>>;
-          (
-            entity?: Param,
-            options?: {
-              rawResponse: true;
-            } & RequestOptions<Awaited<R>>,
-          ): Promise<AxiosResponse<Awaited<R>>>;
-          (entity?: Param, options?: RequestOptions<Awaited<R>>): R;
-        }
-      : // Entity based op parameter names
-        {
-          (entity: Param): R;
-          <F extends keyof Awaited<R>>(
-            entity: Param,
-            options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<R>>,
-          ): Promise<AxiosResponse<Pick<Awaited<R>, F>>>;
-          <F extends keyof Awaited<R>>(
-            entity: Param,
-            options: { fields: F[] } & RequestOptions<Awaited<R>>,
-          ): Promise<Pick<Awaited<R>, F>>;
-          (
-            entity: Param,
-            options?: {
-              rawResponse: true;
-            } & RequestOptions<Awaited<R>>,
-          ): Promise<AxiosResponse<Awaited<R>>>;
-          (entity: Param, options?: RequestOptions<Awaited<R>>): R;
-        };
+  Param extends undefined
+  ? {
+    (query?: Param): Return;
+    <F extends keyof U>(
+      query: Param,
+      options: { fields: F[] } & RequestOptions<U>,
+    ): Return extends AsyncIterable<U>
+      ? Promise<AsyncIterable<Pick<U, F>>>
+      : Return extends Promise<Array<U>>
+      ? Promise<Array<Pick<U, F>>>
+      : Promise<Iterable<Pick<U, F>>>;
+    (query: Param, options?: Opts): Return;
+  }
+  : Partial<Param> extends Param
+  ? {
+    (query?: Param): Return;
+    <F extends keyof U>(
+      query: Param,
+      options: { fields: F[] } & RequestOptions<U>,
+    ): Return extends AsyncIterable<U>
+      ? Promise<AsyncIterable<Pick<U, F>>>
+      : Return extends Promise<Array<U>>
+      ? Promise<Array<Pick<U, F>>>
+      : Promise<Iterable<Pick<U, F>>>;
+    (query?: Param, options?: Opts): Return;
+  }
+  : {
+    (query: Param): Return;
+    <F extends keyof U>(
+      query: Param,
+      options: { fields: F[] } & RequestOptions<U>,
+    ): Return extends AsyncIterable<U>
+      ? Promise<AsyncIterable<Pick<U, F>>>
+      : Return extends Promise<Array<U>>
+      ? Promise<Array<Pick<U, F>>>
+      : Promise<Iterable<Pick<U, F>>>;
+    (query: Param, Options?: Opts): Return;
+  }
+  : // ID based op parameters
+  Param extends number
+  ? {
+    (id: Param): Return;
+    <F extends keyof Awaited<Return>>(
+      id: Param,
+      options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<Return>>,
+    ): Promise<AxiosResponse<Pick<Awaited<Return>, F>>>;
+    <F extends keyof Awaited<Return>>(
+      id: Param,
+      options: { fields: F[] } & RequestOptions<Awaited<Return>>,
+    ): Promise<Pick<Awaited<Return>, F>>;
+    (
+      id: Param,
+      options?: {
+        rawResponse: true;
+      } & RequestOptions<Awaited<Return>>,
+    ): Promise<AxiosResponse<Awaited<Return>>>;
+    (id: Param, options?: RequestOptions<Awaited<Return>>): Return;
+  }
+  : Param extends number[]
+  ? {
+    (ids: Param): Return;
+    <F extends keyof Awaited<Return>>(
+      ids: Param,
+      options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<Return>>,
+    ): Promise<AxiosResponse<Pick<Awaited<Return>, F>>>;
+    <F extends keyof Awaited<Return>>(
+      ids: Param,
+      options: { fields: F[] } & RequestOptions<Awaited<Return>>,
+    ): Promise<Pick<Awaited<Return>, F>>;
+    (
+      ids: Param,
+      options?: {
+        rawResponse: true;
+      } & RequestOptions<Awaited<Return>>,
+    ): Promise<AxiosResponse<Awaited<Return>>>;
+    (ids: Param, options?: RequestOptions<Awaited<Return>>): Return;
+  }
+  : // Undefined based op parameters - ensures ops that don't require a
+  // param aren't forced to specify `undefined` but can if they need to specify
+  // options
+  Param extends undefined
+  ? {
+    (): Return;
+    <F extends keyof Awaited<Return>>(
+      none: Param,
+      options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<Return>>,
+    ): Promise<AxiosResponse<Pick<Awaited<Return>, F>>>;
+    <F extends keyof Awaited<Return>>(
+      none: Param,
+      options: { fields: F[] } & RequestOptions<Awaited<Return>>,
+    ): Promise<Pick<Awaited<Return>, F>>;
+    (
+      none?: Param,
+      options?: {
+        rawResponse: true;
+      } & RequestOptions<Awaited<Return>>,
+    ): Promise<AxiosResponse<Awaited<Return>>>;
+    (none?: Param, options?: RequestOptions<Awaited<Return>>): Return;
+  }
+  : // Entity based op parameter names
+  {
+    (entity: Param): Return;
+    <F extends keyof Awaited<Return>>(
+      entity: Param,
+      options: { fields: F[]; rawResponse: true } & RequestOptions<Awaited<Return>>,
+    ): Promise<AxiosResponse<Pick<Awaited<Return>, F>>>;
+    <F extends keyof Awaited<Return>>(
+      entity: Param,
+      options: { fields: F[] } & RequestOptions<Awaited<Return>>,
+    ): Promise<Pick<Awaited<Return>, F>>;
+    (
+      entity: Param,
+      options?: {
+        rawResponse: true;
+      } & RequestOptions<Awaited<Return>>,
+    ): Promise<AxiosResponse<Awaited<Return>>>;
+    (entity: Param, options?: RequestOptions<Awaited<Return>>): Return;
+  };
 
 /** Wrapper type for expressing the response returned by a v2 list op supported endpoint */
 interface PagedResponse<T> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,11 +50,13 @@ class AssertionError extends Error {
   override name = AssertionError.prototype.name;
 }
 
-/** Ensures the provided value resolves to `true` before continuing
- *
+/** Ensures the provided value resolves to `true` before continuing.
  * If the value doesn't resolve to `true` then the provided `error` will be thrown
  *
  * Intended to be run in production and not removed on build
+ *
+ * We don't use the `node:assert` package as this SDK needs to run in environments like
+ * web and mobile where the `node:assert` package may not be defined.
  *
  * @param assertion assertion to verify
  * @param error error to throw. If `undefined` or a `string` then an {@link AssertionError}
@@ -81,6 +83,7 @@ function toSearchParams(parameters?: Record<string, QueryParameterValue>): URLSe
   return new URLSearchParams(reducedParams);
 }
 
+/** Interceptor for {@link AxiosError}s mapping them into {@link SDKError} */
 function parseClientError(error: AxiosError): SDKError {
   const axiosErrorLocation = error.response || error.request;
   const apiErrorMessage = axiosErrorLocation.data?.message ?? axiosErrorLocation.data?.error;


### PR DESCRIPTION
# Overview

Added documentation via JSDoc comments for functions missing them and on existing doc comments that didn't elaborate enough in my view.

Also updated the `OpFunction` type to have a more descriptive return type name and support op param types with `number[]` showing the parameter name `"ids"` instead of `"entity"` for these op function signatures