### PR TITLE
feat: add max_weekly_hours to User interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "2.3.23",
+  "version": "2.3.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "2.3.23",
+      "version": "2.3.24",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "2.3.23",
+  "version": "2.3.24",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "type": "module",
   "engines": {

--- a/src/interfaces/user.interface.ts
+++ b/src/interfaces/user.interface.ts
@@ -37,6 +37,7 @@ export interface User {
   start_date: string | null;
   final_working_date: string | null;
   weekly_hours: number | null;
+  max_weekly_hours: number | null;
   holiday_allowance: number;
   holiday_allowance_unit: string;
   payroll_id: string | null;


### PR DESCRIPTION
## Summary

- Adds `max_weekly_hours: number | null` to the `User` interface, mirroring the field added in rotacloud-app

## Test plan

- [x] TypeScript compiles (`npm run build`)