### PR TITLE
RPL-739 Adds support for listing shifts through the V2 API in the RotaCloud Node SDK.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "2.3.26",
+  "version": "2.3.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "2.3.26",
+      "version": "2.3.27",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "2.3.26",
+  "version": "2.3.27",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "type": "module",
   "engines": {

--- a/src/client-builder.test.ts
+++ b/src/client-builder.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe, vi } from 'vitest';
 import { Axios } from 'axios';
 import { createSdkClient, DEFAULT_CONFIG } from './client-builder.js';
 import { SDKConfig } from './interfaces/index.js';
+import { ShiftsV2QueryParams } from './interfaces/query-params/index.js';
 import { SERVICES } from './service.js';
 import pkg from '../package.json' with { type: 'json' };
 
@@ -27,6 +28,38 @@ const sdkConfig: SDKConfig = {
 };
 
 describe('SDK client builder', () => {
+  test('V2 shift queries require complete shift or creation date ranges', () => {
+    const shiftDateRange = {
+      start: '2026-07-20T00:00:00.000Z',
+      end: '2026-07-27T00:00:00.000Z',
+    } satisfies ShiftsV2QueryParams;
+    const creationDateRange = {
+      createdAtStart: '2026-07-20T00:00:00.000Z',
+      createdAtEnd: '2026-07-27T00:00:00.000Z',
+    } satisfies ShiftsV2QueryParams;
+    const bothDateRanges = {
+      ...shiftDateRange,
+      ...creationDateRange,
+    } satisfies ShiftsV2QueryParams;
+
+    // @ts-expect-error A date range is required.
+    const empty = {} satisfies ShiftsV2QueryParams;
+    // @ts-expect-error A shift date range requires both boundaries.
+    const partialShiftRange = { start: shiftDateRange.start } satisfies ShiftsV2QueryParams;
+    // @ts-expect-error A creation date range requires both boundaries.
+    const partialCreationRange: ShiftsV2QueryParams = {
+      createdAtStart: creationDateRange.createdAtStart,
+    };
+    // @ts-expect-error A second date range cannot be partial.
+    const completeAndPartialRanges: ShiftsV2QueryParams = {
+      ...shiftDateRange,
+      createdAtStart: creationDateRange.createdAtStart,
+    };
+
+    expect([shiftDateRange, creationDateRange, bothDateRanges]).toHaveLength(3);
+    expect([empty, partialShiftRange, partialCreationRange, completeAndPartialRanges]).toHaveLength(4);
+  });
+
   test('basic services are created', () => {
     const clientBuilder = createSdkClient({
       basicService1: {

--- a/src/client-builder.test.ts
+++ b/src/client-builder.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe, vi } from 'vitest';
 import { Axios } from 'axios';
 import { createSdkClient, DEFAULT_CONFIG } from './client-builder.js';
 import { SDKConfig } from './interfaces/index.js';
+import { SERVICES } from './service.js';
 import pkg from '../package.json' with { type: 'json' };
 
 let mockAxiosClient: Axios;
@@ -94,6 +95,66 @@ describe('SDK client builder', () => {
     expect(mockAxiosClient.request).toHaveBeenCalledWith(
       expect.objectContaining({
         url: 'v1/accounts/1',
+      }),
+    );
+  });
+
+  test('adds V2 shift listing without changing the existing V1 shift service', async () => {
+    const client = createSdkClient({ shift: SERVICES.shift })(sdkConfig);
+    vi.spyOn(mockAxiosClient, 'request')
+      .mockResolvedValueOnce({ data: [], headers: {} })
+      .mockResolvedValueOnce({
+        data: { data: [], pagination: { next: null, count: null } },
+      });
+
+    expect(client.shift).toMatchObject({
+      create: expect.any(Function),
+      get: expect.any(Function),
+      list: expect.any(Function),
+      listAll: expect.any(Function),
+      update: expect.any(Function),
+      updateBatch: expect.any(Function),
+      delete: expect.any(Function),
+      deleteBatch: expect.any(Function),
+      acknowledge: expect.any(Function),
+      history: expect.any(Function),
+      publish: expect.any(Function),
+      unpublish: expect.any(Function),
+      updateSwap: expect.any(Function),
+      updateDrop: expect.any(Function),
+      v2: {
+        list: expect.any(Function),
+        listAll: expect.any(Function),
+      },
+    });
+
+    await client.shift.list({ start: 1, end: 2 }).next();
+    await client.shift.v2
+      .list({
+        start: '2026-07-20T00:00:00.000Z',
+        end: '2026-07-27T00:00:00.000Z',
+        createdBy: [7],
+        hasNotes: true,
+      })
+      .next();
+
+    expect(mockAxiosClient.request).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        url: 'v1/shifts',
+        params: expect.objectContaining({ start: 1, end: 2 }),
+      }),
+    );
+    expect(mockAxiosClient.request).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        url: 'v2/shifts',
+        params: expect.objectContaining({
+          start: '2026-07-20T00:00:00.000Z',
+          end: '2026-07-27T00:00:00.000Z',
+          createdBy: [7],
+          hasNotes: true,
+        }),
       }),
     );
   });

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -28,6 +28,7 @@ import {
   DayNoteV2,
   DayNoteV2QueryParameters,
   PartialUserV2,
+  ShiftV2,
 } from './interfaces/index.js';
 import { LogbookEntry, LogbookQueryParameters } from './interfaces/logbook.interface.js';
 import { Message } from './interfaces/message.interface.js';
@@ -47,6 +48,7 @@ import {
   RolesQueryParams,
   SettingsQueryParams,
   ShiftsQueryParams,
+  ShiftsV2QueryParams,
   TerminalsQueryParams,
   ToilAccrualsQueryParams,
   ToilAllowanceQueryParams,
@@ -122,6 +124,7 @@ export interface EndpointEntityMap extends Record<EndpointVersion, Record<string
   };
   /** Type mappings for v2 endpoints */
   v2: {
+    shifts: Endpoint<ShiftV2, ShiftsV2QueryParams>;
     logbook: Endpoint<LogbookEntry, LogbookQueryParameters, 'name' | 'description' | 'date' | 'userId'>;
     invoices: Endpoint<Invoice, InvoiceQueryParameters>;
     dayNotes: Endpoint<

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -29,6 +29,7 @@ export * from './role.interface.js';
 export * from './sdk-config.interface.js';
 export * from './settings.interface.js';
 export * from './shift.interface.js';
+export * from './shift-v2.interface.js';
 export * from './terminal.interface.js';
 export * from './time-zone.interface.js';
 export * from './toil-accrual.interface.js';

--- a/src/interfaces/query-params/index.ts
+++ b/src/interfaces/query-params/index.ts
@@ -17,6 +17,7 @@ export * from './pay-periods-query-params.interface.js';
 export * from './roles-query-params.interface.js';
 export * from './settings-query-params.interface.js';
 export * from './shifts-query-params.interface.js';
+export * from './shifts-v2-query-params.interface.js';
 export * from './swap-requests-query-params.interface.js';
 export * from './terminals-query-params.interface.js';
 export * from './toil-accruals-query-params.interface.js';

--- a/src/interfaces/query-params/shifts-v2-query-params.interface.ts
+++ b/src/interfaces/query-params/shifts-v2-query-params.interface.ts
@@ -1,7 +1,4 @@
-/** Filters supported by the V2 shifts list endpoint. */
-export interface ShiftsV2QueryParams {
-  start?: string;
-  end?: string;
+interface ShiftsV2Filters {
   ids?: number[];
   users?: number[];
   locations?: number[];
@@ -11,7 +8,28 @@ export interface ShiftsV2QueryParams {
   deleted?: boolean;
   acknowledged?: boolean;
   createdBy?: number[];
-  createdAtStart?: string;
-  createdAtEnd?: string;
   hasNotes?: boolean;
 }
+
+type ShiftDateRange = {
+  start: string;
+  end: string;
+};
+
+type CreationDateRange = {
+  createdAtStart: string;
+  createdAtEnd: string;
+};
+
+/**
+ * Filters supported by the V2 shifts list endpoint.
+ *
+ * At least one complete shift or creation date range is required. Both ranges
+ * may be supplied together, but neither may be supplied partially.
+ */
+export type ShiftsV2QueryParams = ShiftsV2Filters &
+  (
+    | (ShiftDateRange & { createdAtStart?: never; createdAtEnd?: never })
+    | (CreationDateRange & { start?: never; end?: never })
+    | (ShiftDateRange & CreationDateRange)
+  );

--- a/src/interfaces/query-params/shifts-v2-query-params.interface.ts
+++ b/src/interfaces/query-params/shifts-v2-query-params.interface.ts
@@ -1,0 +1,17 @@
+/** Filters supported by the V2 shifts list endpoint. */
+export interface ShiftsV2QueryParams {
+  start?: string;
+  end?: string;
+  ids?: number[];
+  users?: number[];
+  locations?: number[];
+  roles?: number[];
+  open?: boolean;
+  published?: boolean;
+  deleted?: boolean;
+  acknowledged?: boolean;
+  createdBy?: number[];
+  createdAtStart?: string;
+  createdAtEnd?: string;
+  hasNotes?: boolean;
+}

--- a/src/interfaces/shift-v2.interface.ts
+++ b/src/interfaces/shift-v2.interface.ts
@@ -1,0 +1,63 @@
+import type { RequestStatus } from './swap-request.interface.js';
+
+/** A swap request embedded in a V2 shift response. */
+export interface ShiftSwapRequestV2 {
+  id: number;
+  status: RequestStatus;
+  requestedAt: string;
+  userRepliedAt: string | null;
+  adminRepliedAt: string | null;
+  oldUserId: number;
+  newUserId: number;
+  adminId: number | null;
+  userApproved: boolean | null;
+  adminApproved: boolean | null;
+  shiftId: number;
+  swappedShiftId: number | null;
+}
+
+/** A drop request embedded in a V2 shift response. */
+export interface ShiftDropRequestV2 {
+  id: number;
+  status: RequestStatus;
+  requestedAt: string;
+  repliedAt: string | null;
+  userId: number;
+  adminId: number | null;
+  userMessage: string;
+  adminMessage: string;
+  shiftId: number;
+}
+
+/**
+ * A shift returned by the V2 shifts endpoint.
+ *
+ * Manager-only and assigned-user fields are optional because the endpoint
+ * returns a permission-dependent response shape.
+ */
+export interface ShiftV2 {
+  id: number;
+  published: boolean;
+  open: boolean;
+  userId: number | null;
+  locationId: number;
+  roleId: number | null;
+  startTime: string;
+  endTime: string;
+  minutesBreak: number;
+  createdAt: string;
+  dropRequests: ShiftDropRequestV2[];
+  swapRequests: ShiftSwapRequestV2[];
+  notes?: string;
+  claimOpenShiftApprovalRequired: boolean;
+  createdBy?: number | null;
+  updatedBy?: number | null;
+  updatedAt?: string | null;
+  claimedAt?: string | null;
+  claimed?: boolean;
+  acknowledgedAt?: string | null;
+  acknowledged?: boolean;
+  deleted?: boolean;
+  deletedAt?: string | null;
+  deletedBy?: number | null;
+}

--- a/src/ops.test.ts
+++ b/src/ops.test.ts
@@ -33,7 +33,7 @@ describe('Operations', () => {
   const serviceV2 = {
     endpoint: 'logbook',
     endpointVersion: 'v2',
-    operations: ['get', 'delete', 'list'],
+    operations: ['get', 'delete', 'list', 'listAll'],
     customOperations: {
       promiseOp: async () => 3,
     },
@@ -189,6 +189,81 @@ describe('Operations', () => {
           res;
         }
         expect(mockAxiosClient.request).toHaveBeenCalledTimes(pageTotal);
+      });
+
+      test('caps each request at the V2 maximum page size', async () => {
+        vi.spyOn(mockAxiosClient, 'request').mockResolvedValue({
+          data: { data: [], pagination: { next: null, count: 0 } },
+        });
+
+        await client.serviceV2.listAll({ userId: 0 }, { maxResults: 600 });
+
+        expect(mockAxiosClient.request).toHaveBeenCalledWith(
+          expect.objectContaining({
+            params: expect.objectContaining({ limit: 500 }),
+          }),
+        );
+      });
+
+      test('uses the remaining overall limit as the next page size', async () => {
+        vi.spyOn(mockAxiosClient, 'request')
+          .mockResolvedValueOnce({
+            data: {
+              data: new Array(500).fill('entity'),
+              pagination: { next: 'page-2', count: null },
+            },
+          })
+          .mockResolvedValueOnce({
+            data: {
+              data: new Array(250).fill('entity'),
+              pagination: { next: 'unused', count: null },
+            },
+          });
+
+        await expect(client.serviceV2.listAll({ userId: 0 }, { maxResults: 750 })).resolves.toHaveLength(750);
+        expect(mockAxiosClient.request).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({ params: expect.objectContaining({ limit: 500 }) }),
+        );
+        expect(mockAxiosClient.request).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            params: expect.objectContaining({ cursor: 'page-2', limit: 250 }),
+          }),
+        );
+        expect(mockAxiosClient.request).toHaveBeenCalledTimes(2);
+      });
+
+      test('does not request a page when maxResults is zero', async () => {
+        const request = vi.spyOn(mockAxiosClient, 'request');
+
+        await expect(client.serviceV2.listAll({ userId: 0 }, { maxResults: 0 })).resolves.toEqual([]);
+        expect(request).not.toHaveBeenCalled();
+      });
+
+      test('throws when a V2 endpoint repeats a pagination cursor', async () => {
+        vi.spyOn(mockAxiosClient, 'request').mockResolvedValue({
+          data: {
+            data: ['entity'],
+            pagination: { next: 'repeated-cursor', count: null },
+          },
+        });
+
+        await expect(client.serviceV2.listAll({ userId: 0 })).rejects.toThrow(
+          'V2 pagination returned a repeated cursor',
+        );
+        expect(mockAxiosClient.request).toHaveBeenCalledTimes(2);
+      });
+
+      test('accepts a nullable V2 pagination count', async () => {
+        vi.spyOn(mockAxiosClient, 'request').mockResolvedValue({
+          data: {
+            data: ['entity'],
+            pagination: { next: null, count: null },
+          },
+        });
+
+        await expect(client.serviceV2.listAll({ userId: 0 })).resolves.toEqual(['entity']);
       });
 
       test('stops automatic pagination after maxResults reached', async () => {

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -183,8 +183,15 @@ interface PagedResponse<T> {
      */
     next: string | null;
     /** Total count of entities matching the list query */
-    count: number;
+    count: number | null;
   };
+}
+
+const V2_MAX_PAGE_SIZE = 500;
+
+/** Returns a valid V2 page size without exceeding the overall remaining result limit. */
+function v2PageSize(remaining: number): number {
+  return Math.min(V2_MAX_PAGE_SIZE, remaining);
 }
 
 /** For validating the query parameter supplied to list ops
@@ -468,34 +475,46 @@ export async function* listV2Op<T, Query>(
 ): AsyncGenerator<T> {
   validateQueryParameter(query);
 
+  const maxEntities = opts?.maxResults ?? Infinity;
+  if (maxEntities <= 0) return;
+
   const queriedRequest = {
     ...ctx.request,
     url: `${ctx.service.endpointVersion}/${ctx.service.endpoint}`,
     params: {
       ...ctx.request.params,
       ...query,
-      limit: opts?.maxResults,
+      limit: v2PageSize(maxEntities),
     },
   };
   const res = await ctx.client.request<PagedResponse<T>>(queriedRequest);
   const { data: entities, pagination } = res.data;
-  const maxEntities = opts?.maxResults ?? Infinity;
-  let pagedEntityCount = entities.length;
+  let pagedEntityCount = 0;
 
   assert(Array.isArray(entities), 'list can only be performed on endpoints returning an array');
-  yield* entities.slice(0, maxEntities);
-  if (pagedEntityCount >= maxEntities) return;
+  for (const entity of entities) {
+    yield entity;
+    pagedEntityCount += 1;
+    if (pagedEntityCount >= maxEntities) return;
+  }
 
   let nextPage: string | undefined = pagination.next ?? undefined;
+  const visitedCursors = new Set<string>();
   while (nextPage !== undefined) {
+    if (visitedCursors.has(nextPage)) {
+      throw new Error('V2 pagination returned a repeated cursor');
+    }
+    visitedCursors.add(nextPage);
+
     const pagedRes = await ctx.client.request<PagedResponse<T>>({
       ...queriedRequest,
       params: {
         ...queriedRequest.params,
-        limit: pagedEntityCount,
+        limit: v2PageSize(maxEntities - pagedEntityCount),
         cursor: nextPage,
       },
     });
+    assert(Array.isArray(pagedRes.data.data), 'list can only be performed on endpoints returning an array');
     nextPage = pagedRes.data.pagination.next ?? undefined;
     for (const entity of pagedRes.data.data) {
       yield entity;

--- a/src/ops.ts
+++ b/src/ops.ts
@@ -51,7 +51,7 @@ export type OpFunction<Return = any, Param = undefined, Opts = RequestOptions<un
   | AsyncIterable<infer U>
   | Promise<Iterable<infer U>>
   ? // List based op parameter names
-    Param extends undefined
+    [Param] extends [undefined]
     ? {
         (query?: Param): Return;
         <F extends keyof U>(
@@ -64,7 +64,7 @@ export type OpFunction<Return = any, Param = undefined, Opts = RequestOptions<un
             : Promise<Iterable<Pick<U, F>>>;
         (query: Param, options?: Opts): Return;
       }
-    : Partial<Param> extends Param
+    : [Partial<Param>] extends [Param]
       ? {
           (query?: Param): Return;
           <F extends keyof U>(

--- a/src/service.ts
+++ b/src/service.ts
@@ -311,6 +311,13 @@ export const SERVICES = {
     endpoint: 'shifts',
     endpointVersion: 'v1',
     operations: ['create', 'get', 'list', 'listAll', 'update', 'updateBatch', 'delete', 'deleteBatch'],
+    subService: {
+      v2: {
+        endpoint: 'shifts',
+        endpointVersion: 'v2',
+        operations: ['list', 'listAll'],
+      },
+    },
     customOperations: {
       acknowledge: ({ request }, shiftIds: number[]): RequestConfig<{ shifts: number[] }, void> => ({
         ...request,


### PR DESCRIPTION
## What does this PR do?

Adds support for listing shifts through the V2 API in the RotaCloud Node SDK.

## What’s the solution?

- Adds `client.shift.v2.list()` and `client.shift.v2.listAll()`.
- Adds exported V2 shift, swap, drop, and query types.
- Preserves all existing `client.shift` V1 operations unchanged.
- Improves V2 cursor pagination by:
  - limiting individual requests to 500 results;
  - treating `maxResults` as the overall limit;
  - preventing repeated-cursor loops;
  - supporting nullable result counts.
- Requires either a complete shift-date range or creation-date range in V2 shift queries.

## Why?

The web app is migrating shift-list requests to `/v2/shifts`. Providing this through the SDK avoids maintaining a separate request and pagination implementation in the web app.

## Testing

- SDK tests: 26/26 passed.
- Build passed.
- Lint passed with no errors.
- Packed-package consumer typecheck passed.
- Manually verified:
  - `client.shift.list()` continues to call `/v1/shifts`;
  - `client.shift.v2.list()` and `listAll()` call `/v2/shifts`;
  - cursor pagination respects the overall result limit.

## Does this introduce breaking changes?

No. The V2 methods are additive, and existing V1 shift operations remain unchanged.