### PR TITLE
[misc/fix-deleted-type] chore: make deleted non-optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "2.3.27",
+  "version": "2.3.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "2.3.27",
+      "version": "2.3.28",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "2.3.27",
+  "version": "2.3.28",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "type": "module",
   "engines": {

--- a/src/interfaces/shift-v2.interface.ts
+++ b/src/interfaces/shift-v2.interface.ts
@@ -57,7 +57,7 @@ export interface ShiftV2 {
   claimed?: boolean;
   acknowledgedAt?: string | null;
   acknowledged?: boolean;
-  deleted?: boolean;
+  deleted: boolean;
   deletedAt?: string | null;
   deletedBy?: number | null;
 }


### PR DESCRIPTION
Fixes deleted type for V2 Shifts, it is non-optional in the API DTO
<img width="965" height="116" alt="Screenshot 2026-07-31 at 12 49 00" src="https://github.com/user-attachments/assets/5f7f3807-0514-46fb-ad44-8097034c9662" />
