### PR TITLE
ROP-686 feat(shifts): add v2 get-shift-by-ID operation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotacloud",
-  "version": "2.3.27",
+  "version": "2.3.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotacloud",
-      "version": "2.3.27",
+      "version": "2.3.28",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotacloud",
-  "version": "2.3.27",
+  "version": "2.3.28",
   "description": "The RotaCloud SDK for the RotaCloud API",
   "type": "module",
   "engines": {

--- a/src/client-builder.test.ts
+++ b/src/client-builder.test.ts
@@ -5,6 +5,7 @@ import {
   ManagerShiftDropRequestV2,
   ManagerShiftSwapRequestV2,
   SDKConfig,
+  Shift,
   ShiftDropRequestV2,
   ShiftSwapRequestV2,
   ShiftV2,
@@ -263,6 +264,75 @@ describe('SDK client builder', () => {
           createdBy: [7],
           hasNotes: true,
         }),
+      }),
+    );
+  });
+
+  test('adds a typed V2 get-shift-by-ID operation without changing V1 get', async () => {
+    const client = createSdkClient({ shift: SERVICES.shift })(sdkConfig);
+    const v1Shift = {
+      id: 42,
+      deleted: false,
+      deleted_at: null,
+      deleted_by: null,
+      published: true,
+      open: false,
+      start_time: 1_753_651_200,
+      end_time: 1_753_680_000,
+      minutes_break: 30,
+      user: 7,
+      location: 3,
+      role: 4,
+      notes: null,
+      created_at: 1_753_560_000,
+      created_by: 7,
+      updated_at: null,
+      updated_by: null,
+      claimed: false,
+      claimed_at: null,
+      acknowledged: false,
+      acknowledged_at: null,
+      swap_requests: [],
+      unavailability_requests: [],
+    } satisfies Shift;
+    const v2Shift = {
+      id: 42,
+      published: true,
+      open: false,
+      userId: 7,
+      locationId: 3,
+      roleId: 4,
+      startTime: '2026-07-20T09:00:00.000Z',
+      endTime: '2026-07-20T17:00:00.000Z',
+      minutesBreak: 30,
+      createdAt: '2026-07-20T08:00:00.000Z',
+      dropRequests: [],
+      swapRequests: [],
+      claimOpenShiftApprovalRequired: false,
+    } satisfies ShiftV2;
+    vi.spyOn(mockAxiosClient, 'request')
+      .mockResolvedValueOnce({ data: v1Shift })
+      .mockResolvedValueOnce({ data: v2Shift });
+
+    expect(client.shift.v2.get).toEqual(expect.any(Function));
+
+    const v1Result: Shift = await client.shift.get(42);
+    const v2Result: ShiftV2 = await client.shift.v2.get(42);
+
+    expect(v1Result).toBe(v1Shift);
+    expect(v2Result).toBe(v2Shift);
+    expect(mockAxiosClient.request).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: 'GET',
+        url: 'v1/shifts/42',
+      }),
+    );
+    expect(mockAxiosClient.request).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: 'GET',
+        url: 'v2/shifts/42',
       }),
     );
   });

--- a/src/service.ts
+++ b/src/service.ts
@@ -315,7 +315,7 @@ export const SERVICES = {
       v2: {
         endpoint: 'shifts',
         endpointVersion: 'v2',
-        operations: ['list', 'listAll'],
+        operations: ['get', 'list', 'listAll'],
       },
     },
     customOperations: {


### PR DESCRIPTION
## What
Adds a typed `shift.v2.get(id)` operation to the SDK.

## Why
Node API already supports GET /v2/shifts/:id, but the v2 shift service only exposed list and listAll. WEB and Terminal need a typed single-shift op before they can migrate.

## Solution
- Added `get` to the v2 shift service operations in service.ts, picks up the existing versioned `/:id` request builder in ops.ts.
- Returns the existing ShiftV2 response type, v1 shift.get is untouched.

## Unit tests?
Yes.
- client.shift.v2.get exists on the built client
- calling it hits v2/shifts/:id and returns the camel-case ShiftV2 shape
- v1 shift.get still hits v1/shifts/:id and returns the snake-case Shift shape
